### PR TITLE
Some fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,4 +242,4 @@ function formatParamUrl (url) {
   }
 }
 
-module.exports = fp(fastifySwagger, '>=0.14.0')
+module.exports = fp(fastifySwagger, '>=0.27.0')

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ function fastifySwagger (fastify, opts, next) {
         },
         response: {
           200: {
+            type: 'object',
+            properties: {},
+            additionalProperties: true,
             description: 'The swagger definition of the routes'
           }
         }
@@ -91,7 +94,7 @@ function fastifySwagger (fastify, opts, next) {
       for (var i = 0, len = methods.length; i < len; i++) {
         const method = methods[i]
         const route = routes[method]
-        const schema = route.schema.schema
+        const schema = route.schema
         if (schema && schema.hide) {
           if (len === 1) delete swaggerRoute[url]
           continue
@@ -201,24 +204,25 @@ function genResponse (response) {
     return { 200: { description: 'Default Response' } }
   }
 
+  const ret = {}
   Object.keys(response).forEach(key => {
     if (response[key].type) {
       var rsp = response[key]
       var description = response[key].description
       var headers = response[key].headers
-      response[key] = {
+      ret[key] = {
         schema: rsp
       }
-      response[key].description = description || 'Default Response'
-      if (headers) response[key].headers = headers
+      ret[key].description = description || 'Default Response'
+      if (headers) ret[key].headers = headers
     }
 
     if (!response[key].description) {
-      response[key].description = 'Default Response'
+      ret[key].description = 'Default Response'
     }
   })
 
-  return response
+  return ret
 }
 
 // The swagger standard does not accept the url param with ':'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
-    "fastify": "^0.23.0",
+    "fastify": "^0.27.0",
+    "shot": "^3.4.2",
     "standard": "^10.0.2",
     "swagger-parser": "^3.4.1",
     "tap": "^10.7.0"


### PR DESCRIPTION
Update fastify version.
Fix "undefined" support bug ([here](https://github.com/fastify/fastify-swagger/blob/first-implementation/index.js#L32) miss the `type` property)
Avoid to change schema of `Store` configuration