### PR TITLE
replaced url in index.html file for window.location.origin for suppor…

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -72,7 +72,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://localhost:3000/documentation/json",
+    url: `${window.location.origin}/documentation/json`,
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Changed the url property in UI to window.location.origin instead http://localhost:3000/documentation/json for supporting load the json documentation from the same origin of the server, because if i start the server in a port different of 3000 i need to change in the ui manually.
Same with the localhost uri, because if a upload to a server and i need to acces via ip the ui doesnt reach http://localhost/documentation/json