### PR TITLE
Support serving `/documentation` from prefixed path

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -72,7 +72,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: `${window.location.origin}/documentation/json`,
+    url: resolveUrl('./documentation/json'),
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -86,6 +86,12 @@ window.onload = function() {
   })
 
   window.ui = ui
+
+  function resolveUrl (url) {
+      const anchor = document.createElement('a')
+      anchor.href = url
+      return anchor.href
+  }
 }
 </script>
 </body>


### PR DESCRIPTION
Currently, if we try to register fastify-swagger inside a [route-prefixed plugin](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing), 
when we try to use the Swagger UI, we see in big letters "Failed to load spec." (and a message like `GET http://localhost:3002/documentation/json 404 (Not Found)` in the browser console).

This PR fixes the URL used to load the spec (`./documentation/json`), so that it's directory is the same as the other assets (e.g. `./documentation/swagger-ui.css`) which already work with prefixed paths.