### PR TITLE
fixes empty response #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,8 @@ function genResponse (response) {
 
   Object.keys(response).forEach(key => {
     if (response[key].type) {
+      if (response[key].type === 'null') delete response[key].type
+
       var rsp = response[key]
       var description = response[key].description
       var headers = response[key].headers


### PR DESCRIPTION
This is a simple fix. The trouble stems from making response objects for swagger from fastify responses. Fastify responses require a type because they all handed off for validation. Having an undefined type is no dice for the validator but 'null' is valid.

Safe to say, empty responses don't have a type, so setting type to 'null' makes this explicit for fastify. ie.

    response: {
      204: {
        description: 'Successful deleted item',
        type: 'null'
      }
    },

When null is set for empty responses, this change ensures it is looked up and the type property deleted when converted to a swagger response. This leaves the description only for documentation that works for swagger.

![screen shot 2018-01-06 at 11 26 53 pm](https://user-images.githubusercontent.com/13335501/34646235-2f2ce774-f339-11e7-9855-5b65ca54d5b4.png)
