### PR TITLE
Use onRoute Hook instead of iterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
-    "fastify": "^0.39.0",
+    "fastify": "^0.43.0",
     "standard": "^10.0.3",
     "swagger-parser": "^4.0.1",
     "tap": "^11.0.0"


### PR DESCRIPTION
Changes to `fastify-swagger` to make it compatible with `fastify` `0.43.0`:
- Use onRoute Hook instead of iterator
- Update version of the `fastify` dependency

Implemented #22 
Fixes #26 