### PR TITLE
add route consumes to swagger documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,10 @@ function fastifySwagger (fastify, opts, next) {
           swaggerMethod.tags = schema.tags
         }
 
+        if (schema.consumes) {
+          swaggerMethod.consumes = schema.consumes
+        }
+
         if (schema.querystring) {
           getQueryParams(parameters, schema.querystring)
         }

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -343,3 +343,39 @@ test('deprecated route', t => {
       })
   })
 })
+
+test('route meta info', t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, swaggerInfo)
+
+  const opts = {
+    schema: {
+      summary: 'Route summary',
+      tags: ['tag'],
+      description: 'Route description',
+      consumes: ['application/x-www-form-urlencoded']
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    const swaggerObject = fastify.swagger()
+
+    Swagger.validate(swaggerObject)
+      .then(function (api) {
+        const definedPath = api.paths['/'].get
+        t.ok(definedPath)
+        t.equal(opts.schema.summary, definedPath.summary)
+        t.same(opts.schema.tags, definedPath.tags)
+        t.equal(opts.schema.description, definedPath.description)
+        t.same(opts.schema.consumes, definedPath.consumes)
+      })
+      .catch(function (err) {
+        t.fail(err)
+      })
+  })
+})


### PR DESCRIPTION
In swagger documentation the `consumes` property can be specified at top level or on a per-route basis. 

This PR adds the `consumes` property if specified at route level. This is important for swagger-ui too insofar as users can "try out" endpoints only with the content-type specified per route