### PR TITLE
Parse request form params

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,18 +192,14 @@ function getBodyParams (parameters, body) {
 
 function getFormParams (parameters, body) {
   const formParamsSchema = body.properties
-  if (!formParamsSchema) {
-
-  } else {
-    const formParams = Object.keys(formParamsSchema).reduce((acc, name) => {
-      acc.push({
-        in: 'formData',
-        name,
-        ...formParamsSchema[name]
-      })
-      return acc
-    }, [])
-    parameters.push(...formParams)
+  if (formParamsSchema) {
+    Object.keys(formParamsSchema).forEach(name => {
+      const param = formParamsSchema[name]
+      delete param.$id
+      param.in = 'formData'
+      param.name = name
+      parameters.push(param)
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function fastifySwagger (fastify, opts, next) {
         }
 
         if (schema.consumes) {
-          swaggerMethod.consumes = schema.consumes
+          swaggerMethod.consumes = schema.consumes;
         }
 
         if (schema.querystring) {

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -129,6 +129,22 @@ const opts6 = {
   }
 }
 
+const opts7 = {
+  schema: {
+    consumes: ['application/x-www-form-urlencoded'],
+    body: {
+      type: 'object',
+      properties: {
+        hello: {
+          description: 'hello',
+          type: 'string'
+        }
+      },
+      required: ['hello']
+    }
+  }
+}
+
 test('fastify.swagger should exist', t => {
   t.plan(2)
   const fastify = Fastify()
@@ -373,6 +389,33 @@ test('route meta info', t => {
         t.same(opts.schema.tags, definedPath.tags)
         t.equal(opts.schema.description, definedPath.description)
         t.same(opts.schema.consumes, definedPath.consumes)
+      })
+      .catch(function (err) {
+        t.fail(err)
+      })
+  })
+})
+
+test('parses form parameters when all api consumes application/x-www-form-urlencoded', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, swaggerInfo)
+  fastify.get('/', opts7, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    const swaggerObject = fastify.swagger()
+
+    Swagger.validate(swaggerObject)
+      .then(function (api) {
+        const definedPath = api.paths['/'].get
+        t.ok(definedPath)
+        t.same(definedPath.parameters, [{
+          in: 'formData',
+          name: 'hello',
+          description: 'hello',
+          type: 'string'
+        }])
       })
       .catch(function (err) {
         t.fail(err)


### PR DESCRIPTION
https://github.com/fastify/fastify-formbody parses request body regardless of whether content-type is json or application/x-www-form-urlencoded
However, swagger has different schemas for json and application/x-www-form-urlencoded, multipart/form-data

This PR distinguishes between the two