### PR TITLE
serving oauth2-redirect.html; /documentation => /documentation/;

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you pass `{ exposeRoute: true }` during the registration the plugin will expo
 |-------|----------------|
 |`'/documentation/json'` | the json object representing the api  |
 |`'/documentation/yaml'` | the yaml object representing the api  |
-|`'/documentation'` | the swagger ui  |
+|`'/documentation/'` | the swagger ui  |
 
 <a name="swagger.options"></a>
 ### swagger options

--- a/routes.js
+++ b/routes.js
@@ -6,6 +6,7 @@ const resolve = require('path').resolve
 
 const files = {
   'index.html': {type: 'text/html'},
+  'oauth2-redirect.html': {type: 'text/html'},
   'swagger-ui.css': {type: 'text/css'},
   'swagger-ui.css.map': {type: 'application/json'},
   'swagger-ui-bundle.js': {type: 'application/javascript'},
@@ -42,7 +43,7 @@ function fastifySwagger (fastify, opts, next) {
     url: '/documentation',
     method: 'GET',
     schema: { hide: true },
-    handler: sendStaticFiles
+    handler: (request, reply) => reply.redirect(request.raw.url + '/')
   })
 
   fastify.route({

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="./documentation/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <style>
     html
     {
@@ -65,14 +65,14 @@
 
 <div id="swagger-ui"></div>
 
-<script src="./documentation/swagger-ui-bundle.js"> </script>
-<script src="./documentation/swagger-ui-standalone-preset.js"> </script>
+<script src="./swagger-ui-bundle.js"> </script>
+<script src="./swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
-  
   // Build a system
   const ui = SwaggerUIBundle({
-    url: resolveUrl('./documentation/json'),
+    url: resolveUrl('./json'),
+    oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html'),
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/test/route.js
+++ b/test/route.js
@@ -164,8 +164,8 @@ test('fastify.swagger should return a valid swagger yaml', t => {
   })
 })
 
-test('/documenatation should send the swagger UI html', t => {
-  t.plan(4)
+test('/documenatation should redirect to /documentation/', t => {
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerInfo)
@@ -182,20 +182,18 @@ test('/documenatation should send the swagger UI html', t => {
     url: '/documentation'
   }, (err, res) => {
     t.error(err)
+    t.strictEqual(res.statusCode, 302)
+    t.strictEqual(res.headers['location'], '/documentation/')
     t.is(typeof res.payload, 'string')
-    t.is(res.headers['content-type'], 'text/html')
     t.strictEqual(
-      readFileSync(
-        resolve(__dirname, '..', 'static', 'index.html'),
-        'utf8'
-      ),
+      '',
       res.payload
     )
   })
 })
 
 test('/documenatation/:file should send back the correct file', t => {
-  t.plan(16)
+  t.plan(20)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerInfo)
@@ -217,6 +215,22 @@ test('/documenatation/:file should send back the correct file', t => {
     t.strictEqual(
       readFileSync(
         resolve(__dirname, '..', 'static', 'index.html'),
+        'utf8'
+      ),
+      res.payload
+    )
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/oauth2-redirect.html'
+  }, (err, res) => {
+    t.error(err)
+    t.is(typeof res.payload, 'string')
+    t.is(res.headers['content-type'], 'text/html')
+    t.strictEqual(
+      readFileSync(
+        resolve(__dirname, '..', 'static', 'oauth2-redirect.html'),
         'utf8'
       ),
       res.payload


### PR DESCRIPTION
Started to integrate my swagger plus OAuth security schema and met an issue with `fastify-swagger`.
Seems we are only serving `index.html`, but not the other file.

Plus, right now it's not actually possible to use it under the url `/documentation/` (it will serve html, but  will not be able to load `css` and `js`). Therefore I've changed the paths to the absolute ones.

It works both `/documentation` and `/documentation/` right now.

As per `oauth2-redirect.html` - starting to serve it.

~~seems to be good, but I did not check the full cycle yet.~~
I can confirm that the full cycle "works on my machine".