### PR TITLE
Fix: Wrong redirect #69

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -7,11 +7,10 @@ function fastifySwagger (fastify, opts, next) {
     url: '/',
     method: 'GET',
     schema: { hide: true },
-		handler: (request, reply) => {
-			const url = fastify.basePath.replace(/\/?$/, '/');
-
-			reply.redirect(`${url}index.html`);
-		}
+      handler: (request, reply) => {
+        const url = fastify.basePath.replace(/\/?$/, '/');
+        reply.redirect(`${url}index.html`);
+      }
   })
 
   fastify.route({

--- a/routes.js
+++ b/routes.js
@@ -7,7 +7,11 @@ function fastifySwagger (fastify, opts, next) {
     url: '/',
     method: 'GET',
     schema: { hide: true },
-    handler: (request, reply) => reply.redirect(`${fastify.basePath}/index.html`)
+		handler: (request, reply) => {
+			const url = fastify.basePath.replace(/\/?$/, '/');
+
+			reply.redirect(`${url}index.html`);
+		}
   })
 
   fastify.route({


### PR DESCRIPTION
Fix for https://github.com/fastify/fastify-swagger/issues/69

If the trailing slash does not exist, a '/' is appended to the end