### PR TITLE
introducing postProcessor for static mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,17 @@ fastify.ready(err => {
   {
     mode: 'static',
     specification: {
-      path: './examples/example-static-specification.yaml'
+      path: './examples/example-static-specification.yaml',
+      postProcessor: function(swaggerObject) {
+        return swaggerObject
+      }
     }
   }
   ```
   Example of the `fastify-swagger` usage in the `static` mode is available [here](examples/static-file.js).
+
+  `specification.postProcessor` parameter is optional. It allows you to change your swagger object on the fly (for example - based on the environment). It accepts `swaggerObject` - basically a javascript object which was parsed from your `yaml` or `json` file and should return a swagger object.
+
 <a name="additional"></a>
 #### additional
 If you pass `{ exposeRoute: true }` during the registration the plugin will expose the documentation with the following apis:
@@ -188,7 +194,7 @@ Global security definitions and route level security provide documentation only.
 In order to start development run:
 ```
 npm i
-npm run prepare:swagger-ui
+npm run prepare
 ```
 
 So that [swagger-ui](https://github.com/swagger-api/swagger-ui) static folder will be generated for you.

--- a/static.js
+++ b/static.js
@@ -18,6 +18,8 @@ module.exports = function (fastify, opts, next) {
   const extName = path.extname(opts.specification.path).toLowerCase()
   if (['.yaml', '.json'].indexOf(extName) === -1) return next(new Error("specification.path extension name is not supported, should be one from ['.yaml', '.json']"))
 
+  if (opts.specification.postProcessor && typeof opts.specification.postProcessor !== 'function') return next(new Error('specification.postProcessor should be a function'))
+
   // read
   const source = fs.readFileSync(
     path.resolve(opts.specification.path),
@@ -30,6 +32,11 @@ module.exports = function (fastify, opts, next) {
     case '.json':
       swaggerObject = JSON.parse(source)
       break
+  }
+
+  // apply postProcessor, if one was passed as an argument
+  if (opts.specification.postProcessor) {
+    swaggerObject = opts.specification.postProcessor(swaggerObject)
   }
 
   fastify.decorate('swagger', swagger)

--- a/tap-snapshots/test-static.js-TAP.test.js
+++ b/tap-snapshots/test-static.js-TAP.test.js
@@ -25,6 +25,10 @@ exports[`test/static.js TAP specification validation check works > undefined 5`]
 Error: /hello/lionel.richie does not exist
 `
 
+exports[`test/static.js TAP specification validation check works > undefined 6`] = `
+Error: specification.postProcessor should be a function
+`
+
 exports[`test/static.js TAP swagger route returns json > undefined 1`] = `
 {
   "openapi": "3.0.0",
@@ -77,4 +81,39 @@ exports[`test/static.js TAP swagger route returns json > undefined 1`] = `
     }
   }
 }
+`
+
+exports[`test/static.js TAP postProcessor works, swagger route returns updated yaml > undefined 1`] = `
+openapi: 3.0.0
+info:
+  description: Test swagger specification
+  version: 1.0.0
+  title: Test swagger specification
+  contact:
+    email: super.developer@gmail.com
+servers:
+  - url: 'http://localhost:4000/'
+    description: Localhost (uses test data)
+paths:
+  /status:
+    get:
+      description: 'Status route, so we can check if server is alive'
+      tags:
+        - Status
+      responses:
+        '200':
+          description: Server is alive
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  health:
+                    type: boolean
+                  date:
+                    type: string
+                example:
+                  health: true
+                  date: '2018-02-19T15:36:46.758Z'
+
 `


### PR DESCRIPTION
🤚,

I suggest to introduce an option of `postProcessor` to be able dynamically adjust the static file, for example based on the environment you run your application on.

My use case - I have auth integrated into the swagger specification:
```
oAuth2Code:
      type: oauth2
      description: OAuth
      flows:
        authorizationCode:
          authorizationUrl: https://localhost:9000/and/it/goes/further
          tokenUrl: https://localhost:9000/and/it/goes/further
          scopes:
            adminLogin: "Login as admin"
```

These urls are different for `localhost`/`development`/`staging`/`whatever`.

Having a `postProcessor` option will allow me to inject them based on the `NODE_ENV` and `config`, at the same time keeping something as the default value.

Regards,