### PR TITLE
enum configures in path params is missing

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -237,12 +237,10 @@ function getPathParams (parameters, params) {
   }
 
   Object.keys(params).forEach(p => {
-    const param = {}
+    const param = Object.assign({}, params[p])
     param.name = p
     param.in = 'path'
     param.required = true
-    param.description = params[p].description
-    param.type = params[p].type
     parameters.push(param)
   })
 }


### PR DESCRIPTION
For the following schema configure:
```
{
  params: {
    type: 'object',
    properties: {
      enumKey: {type: 'string', enum: ['enum1', 'enum2']}
   }
  }
}
```
the expected swagger json result should not omit the **enum: ["enum1", "enum2"]** part
