### PR TITLE
feature: support explicitly passed document #97

### DIFF
--- a/tap-snapshots/test-static.js-TAP.test.js
+++ b/tap-snapshots/test-static.js-TAP.test.js
@@ -117,3 +117,13 @@ paths:
                   date: '2018-02-19T15:36:46.758Z'
 
 `
+
+exports[`test/static.js TAP swagger route returns explicitly passed doc > undefined 1`] = `
+{
+  "info": {
+    "title": "Test swagger",
+    "description": "testing the fastify swagger api",
+    "version": "0.1.0"
+  }
+}
+`

--- a/tap-snapshots/test-static.js-TAP.test.js
+++ b/tap-snapshots/test-static.js-TAP.test.js
@@ -14,7 +14,7 @@ Error: specification is not an object
 `
 
 exports[`test/static.js TAP specification validation check works > undefined 3`] = `
-Error: specification.path is missing, should be path to the file
+Error: both specification.path and specification.document are missing, should be path to the file or swagger document spec
 `
 
 exports[`test/static.js TAP specification validation check works > undefined 4`] = `

--- a/test/static.js
+++ b/test/static.js
@@ -140,3 +140,41 @@ test('postProcessor works, swagger route returns updated yaml', t => {
     }
   )
 })
+test('swagger route returns explicitly passed doc', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const document = {
+    info: {
+      title: 'Test swagger',
+      description: 'testing the fastify swagger api',
+      version: '0.1.0'
+    }
+  }
+  fastify.register(fastifySwagger, {
+    mode: 'static',
+    specification: {
+      document
+    },
+    exposeRoute: true
+  })
+
+  // check that json is there
+  fastify.inject(
+    {
+      method: 'GET',
+      url: '/documentation/json'
+    },
+    (err, res) => {
+      t.error(err)
+
+      try {
+        var payload = JSON.parse(res.payload)
+        t.matchSnapshot(JSON.stringify(payload, null, 2))
+        t.pass('valid explicitly passed spec document')
+      } catch (error) {
+        t.fail(error)
+      }
+    }
+  )
+})


### PR DESCRIPTION
resolves #97 by adding `document` property which accepts valid JavaScript object (already loaded & parsed swagger specification)