### PR TITLE
Make Security Definitions example align

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fastify.put('/some-route/:id', {
     },
     security: [
       {
-        "api_key": []
+        "apiKey": []
       }
     ]
   }


### PR DESCRIPTION
https://github.com/fastify/fastify-swagger/issues/122 securityDefinitions apiKey needs to be spelled the same as route security apiKey