### PR TITLE
Fixes for fastify v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-swagger.svg)](https://greenkeeper.io/)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)  [![Build Status](https://travis-ci.org/fastify/fastify-swagger.svg?branch=master)](https://travis-ci.org/fastify/fastify-swagger)
 
-[Swagger](https://swagger.io/) documentation generator for Fastify. Supports Fastify versions `^1.9.0`.
+[Swagger](https://swagger.io/) documentation generator for Fastify.
 It uses the schemas you declare in your routes to generate a swagger compliant doc.
+
+Supports Fastify versions `>=2.0.0`. Please refer to [this branch](https://github.com/fastify/fastify-swagger/tree/1.x) and related versions for Fastify `^1.9.0` compatibility.
 
 <a name="install"></a>
 ## Install

--- a/index.js
+++ b/index.js
@@ -23,6 +23,6 @@ function fastifySwagger (fastify, opts, next) {
 }
 
 module.exports = fp(fastifySwagger, {
-  fastify: '>=0.39.0',
+  fastify: '>=2.0.0',
   name: 'fastify-swagger'
 })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
-    "fastify": "^1.9.0",
+    "fastify": "next",
     "fs-extra": "^7.0.0",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.1",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^1.2.0",
-    "fastify-static": "^1.0.0",
+    "fastify-static": "next",
     "js-yaml": "^3.12.0"
   },
   "standard": {

--- a/routes.js
+++ b/routes.js
@@ -8,10 +8,10 @@ function fastifySwagger (fastify, opts, next) {
     method: 'GET',
     schema: { hide: true },
     handler: (request, reply) => {
-      if (fastify.basePath === '/') {
+      if (fastify.prefix === '/') {
         reply.redirect('/index.html')
       } else {
-        reply.redirect(`${fastify.basePath}/index.html`)
+        reply.redirect(`${fastify.prefix}/index.html`)
       }
     }
   })

--- a/test/route.js
+++ b/test/route.js
@@ -265,7 +265,7 @@ test('with routePrefix: \'/\' should redirect to /index.html', t => {
 })
 
 test('/documentation/:file should send back the correct file', t => {
-  t.plan(21)
+  t.plan(19)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerInfo)
@@ -282,16 +282,8 @@ test('/documentation/:file should send back the correct file', t => {
     url: '/documentation/'
   }, (err, res) => {
     t.error(err)
-    t.is(typeof res.payload, 'string')
-    t.is(res.headers['content-type'], 'text/html; charset=UTF-8')
-    t.strictEqual(
-      readFileSync(
-        resolve(__dirname, '..', 'static', 'index.html'),
-        'utf8'
-      ),
-      res.payload
-    )
-    t.ok(res.payload.indexOf('resolveUrl') !== -1)
+    t.is(res.statusCode, 302)
+    t.is(res.headers['location'], '/documentation/index.html')
   })
 
   fastify.inject({


### PR DESCRIPTION
Tests fail but I couldn't figure out. The redirect for `/documentation` -> `/documentation/index.html` does not return any payload for some reason

Failing test: https://github.com/fastify/fastify-swagger/blob/master/test/route.js#L286

Failing line: https://github.com/fastify/fastify-swagger/blob/master/routes.js#L14

Any ideas?