### PR TITLE
swagger-schema-official is now required externally, thus put to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
-    "@types/swagger-schema-official": "^2.0.13",
     "fastify": "^1.9.0",
     "fs-extra": "^7.0.0",
     "pre-commit": "^1.2.2",
@@ -41,6 +40,7 @@
     "tap": "^12.0.0"
   },
   "dependencies": {
+    "@types/swagger-schema-official": "^2.0.13",
     "fastify-plugin": "^1.2.0",
     "fastify-static": "^1.0.0",
     "js-yaml": "^3.12.0"


### PR DESCRIPTION
My package.json contains:

```
  "dependencies": {
    "fastify-plugin": "^1.3.0",
    "fastify-swagger": "^0.16.1",
...
    "protobufjs": "^6.8.8",
    "revane": "^1.0.1",
    "revane-fastify": "^0.3.0",
    "thunk-redis": "^2.2.3"
  },
```

I call `$ npm run test` and get the following error message

```
> article-service@1.0.0 test /home/plipp/work/OBI/obi-neu/article-service
> npm run compile && npm run unit


> article-service@1.0.0 compile /home/plipp/work/OBI/obi-neu/article-service
> tsc

node_modules/fastify-swagger/index.d.ts:3:32 - error TS2307: Cannot find module 'swagger-schema-official'.

3 import * as SwaggerSchema from 'swagger-schema-official';
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! article-service@1.0.0 compile: `tsc`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the article-service@1.0.0 compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/plipp/.npm/_logs/2018-12-10T12_11_35_152Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! article-service@1.0.0 test: `npm run compile && npm run unit`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the article-service@1.0.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
...
```