### PR TITLE
This bugfix is related to #137 PR

### DIFF
--- a/prepare-swagger-ui.js
+++ b/prepare-swagger-ui.js
@@ -32,7 +32,7 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
   }`)
   .replace(
     /url: "(.*)",/,
-    `url: resolveUrl('./json'),
+    `url: resolveUrl('./json').replace('static/json', 'json'),
     oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html'),`
   )
 


### PR DESCRIPTION
Since we added prefix `/static` to separate swagger ui static files from other files we need to make sure that client wlll not use `/static` prefix for other calls (like for retrieving swagger.yaml)