### PR TITLE
Fix `basePath` support

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -96,7 +96,10 @@ module.exports = function (fastify, opts, next) {
       const schema = transform
         ? transform(route.schema)
         : route.schema
-      const url = formatParamUrl(route.url)
+      const path = route.url.startsWith(basePath)
+        ? route.url.replace(basePath, '')
+        : route.url
+      const url = formatParamUrl(path)
 
       const swaggerRoute = swaggerObject.paths[url] || {}
 

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -608,3 +608,25 @@ test('basePath support', t => {
     t.ok(swaggerObject.paths['/endpoint'])
   })
 })
+
+test('basePath support with prefix', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    prefix: '/prefix',
+    swagger: Object.assign({}, swaggerInfo.swagger, {
+      basePath: '/prefix'
+    })
+  })
+
+  fastify.get('/endpoint', {}, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths['/prefix/endpoint'])
+    t.ok(swaggerObject.paths['/endpoint'])
+  })
+})

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -587,3 +587,24 @@ test('swagger json output should not omit enum part in params config', t => {
       })
   })
 })
+
+test('basePath support', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    swagger: Object.assign({}, swaggerInfo.swagger, {
+      basePath: '/prefix'
+    })
+  })
+
+  fastify.get('/prefix/endpoint', {}, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths['/prefix/endpoint'])
+    t.ok(swaggerObject.paths['/endpoint'])
+  })
+})


### PR DESCRIPTION
Hi,

this fixes `basePath` support when routes are defined with prefixes.

Best,
Patrick