### PR TITLE
Bugfix missing `operationid` and `produces` route property

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -116,6 +116,10 @@ module.exports = function (fastify, opts, next) {
       // All the data the user can give us, is via the schema object
       if (schema) {
         // the resulting schema will be in this order
+        if (schema.operationId) {
+          swaggerMethod.operationId = schema.operationId
+        }
+
         if (schema.summary) {
           swaggerMethod.summary = schema.summary
         }

--- a/dynamic.js
+++ b/dynamic.js
@@ -132,6 +132,10 @@ module.exports = function (fastify, opts, next) {
           swaggerMethod.tags = schema.tags
         }
 
+        if (schema.produces) {
+          swaggerMethod.produces = schema.produces
+        }
+
         if (schema.consumes) {
           swaggerMethod.consumes = schema.consumes
         }

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -438,16 +438,18 @@ test('deprecated route', t => {
 })
 
 test('route meta info', t => {
-  t.plan(6)
+  t.plan(8)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerInfo)
 
   const opts = {
     schema: {
+      operationId: 'doSomething',
       summary: 'Route summary',
       tags: ['tag'],
       description: 'Route description',
+      produces: ['application/octet-stream'],
       consumes: ['application/x-www-form-urlencoded']
     }
   }
@@ -462,9 +464,11 @@ test('route meta info', t => {
       .then(function (api) {
         const definedPath = api.paths['/'].get
         t.ok(definedPath)
+        t.equal(opts.schema.operationId, definedPath.operationId)
         t.equal(opts.schema.summary, definedPath.summary)
         t.same(opts.schema.tags, definedPath.tags)
         t.equal(opts.schema.description, definedPath.description)
+        t.same(opts.schema.produces, definedPath.produces)
         t.same(opts.schema.consumes, definedPath.consumes)
       })
       .catch(function (err) {


### PR DESCRIPTION
This is an optional field: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-5