### PR TITLE
Added hide property to RouterSchema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ declare module 'fastify' {
   }
 
   interface RouteSchema {
+    hide?: boolean;
     tags?: string[];
     description?: string;
     summary?: string;


### PR DESCRIPTION
Fixes `TS2322: { hide: boolean; } is not assignable to type 'RouteSchema'`

```typescript
const schema: RouteSchema = {hide: true};
```