### PR TITLE
Fix typing: array definition

### DIFF
--- a/http2-types.test.ts
+++ b/http2-types.test.ts
@@ -26,6 +26,14 @@ app.put('/some-route/:id', {
     }
   }, (req, reply) => {});
 
+app.get('/public/route', {
+  schema: {
+    description: 'returns 200 OK',
+    summary: 'qwerty',
+    security: []
+  }
+}, (req, reply) => {});
+
 app
   .register(fastifySwagger, {
     routePrefix: '/documentation',

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ declare module 'fastify' {
     description?: string;
     summary?: string;
     consumes?: string[];
-    security?: [{ [securityLabel: string]: string[] }];
+    security?: Array<{ [securityLabel: string]: string[] }>;
   }
 }
 

--- a/types.test.ts
+++ b/types.test.ts
@@ -25,6 +25,14 @@ app.put('/some-route/:id', {
     }
   }, (req, reply) => {});
 
+app.get('/public/route', {
+    schema: {
+      description: 'returns 200 OK',
+      summary: 'qwerty',
+      security: []
+    }
+  }, (req, reply) => {});
+
 app
   .register(fastifySwagger, {
     routePrefix: '/documentation',


### PR DESCRIPTION
The old typing throws TypeError when using `security: []` definition in endpoint schema:

![image](https://user-images.githubusercontent.com/9721838/69872514-e050e580-12b5-11ea-90f6-97b2c1d3cd10.png)

Workaround for that is to use `[{}]` as seen with `const b`, but that in turn confuses Swagger UI which renders it as secured, pre-authenticated endpoint:

![image](https://user-images.githubusercontent.com/9721838/69872238-2a859700-12b5-11ea-92a7-dd7b092dd440.png)

This new typing fixes that:

![image](https://user-images.githubusercontent.com/9721838/69872595-1726fb80-12b6-11ea-8452-4f278db046b5.png)
![image](https://user-images.githubusercontent.com/9721838/69872643-3e7dc880-12b6-11ea-9ab7-86ecab75f61b.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
