### PR TITLE
Add "exposeRoute:true" in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ fastify.register(require('fastify-swagger'), {
         in: 'header'
       }
     }
-  }
+  },
+  exposeRoute: true
 })
 
 fastify.put('/some-route/:id', {


### PR DESCRIPTION
The default of `exposeRoute` is `false` which leads to a 404 error:

{"message":"Route GET:/documentation not found","error":"Not Found","statusCode":404}

