### PR TITLE
Ensure paths start with a leading slash

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -96,9 +96,12 @@ module.exports = function (fastify, opts, next) {
       const schema = transform
         ? transform(route.schema)
         : route.schema
-      const path = route.url.startsWith(basePath)
+      let path = route.url.startsWith(basePath)
         ? route.url.replace(basePath, '')
         : route.url
+      if (!path.startsWith('/')) {
+        path = '/' + path
+      }
       const url = formatParamUrl(path)
 
       const swaggerRoute = swaggerObject.paths[url] || {}

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -634,3 +634,46 @@ test('basePath support with prefix', t => {
     t.ok(swaggerObject.paths['/endpoint'])
   })
 })
+
+test('basePath ensure leading slash', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    swagger: Object.assign({}, swaggerInfo.swagger, {
+      basePath: '/'
+    })
+  })
+
+  fastify.get('/endpoint', {}, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths.endpoint)
+    t.ok(swaggerObject.paths['/endpoint'])
+  })
+})
+
+test('basePath with prefix ensure leading slash', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    prefix: '/',
+    swagger: Object.assign({}, swaggerInfo.swagger, {
+      basePath: '/'
+    })
+  })
+
+  fastify.get('/endpoint', {}, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths.endpoint)
+    t.ok(swaggerObject.paths['/endpoint'])
+  })
+})


### PR DESCRIPTION
Fixes #232 

#### Checklist

- [x] run `npm run test`
- [ ] `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

I personally would remove the whole thing about stripping the basePath from paths, but since that would be a breaking change I decided against it.