### PR TITLE
WIP: Add support for multiple dynamic configs

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -45,7 +45,7 @@ function makeSetupFn (opts, idx, fastify, routes, next) {
 
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'
-    fastify.register(require('./routes'), { prefix, conf_idx: idx })
+    fastify.register(require('./routes'), { prefix, confIdx: idx })
   }
 
   const cache = {

--- a/routes.js
+++ b/routes.js
@@ -25,7 +25,7 @@ function fastifySwagger (fastify, opts, next) {
     method: 'GET',
     schema: { hide: true },
     handler: function (req, reply) {
-      reply.send(fastify.swagger())
+      reply.send(fastify.swagger({}, opts.conf_idx))
     }
   })
 

--- a/routes.js
+++ b/routes.js
@@ -25,7 +25,7 @@ function fastifySwagger (fastify, opts, next) {
     method: 'GET',
     schema: { hide: true },
     handler: function (req, reply) {
-      reply.send(fastify.swagger({}, opts.conf_idx))
+      reply.send(fastify.swagger({}, opts.confIdx))
     }
   })
 


### PR DESCRIPTION
Sometimes it may make sense to generate slightly different
documentations based on the same routes by relying on the
`transform` option.

My specific scenario involves serving both a full and a limited
versions of the documentation. Here is my config:
```
app.register(fastifySwagger, [
    {
        routePrefix: '/limited-documentation-for-3rd-parties',
        transform: schema => ({...schema, hide: !schema.public}),
        exposeRoute: true,
    },
    {
        routePrefix: '/protected-full-documentation-for-our-clients',
        exposeRoute: true,
    }
])

```

The feature only applies to the `dynamic` mode and is backwards
compatible.

If anybody shows any interest to this feature; I can complete the PR by
sending tests, benchmarks and docs.

Feedbacks are welcome.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
