### PR TITLE
fix: Correct types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,4 +62,4 @@ type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOption
 
 declare const fastifySwagger: FastifyPlugin<SwaggerOptions>
 
-export default fastifySwagger;
+export = fastifySwagger;

--- a/test/types/http2-types.test.ts
+++ b/test/types/http2-types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger from '../..';
+import fastifySwagger = require('../..');
 
 const app = fastify({
   http2: true

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger from '../..';
+import fastifySwagger = require('../..');
 
 const app = fastify();
 


### PR DESCRIPTION
Partial revert of https://github.com/fastify/fastify-swagger/pull/238/commits/530514a394c58fa8d26b5084a813de2b49a42d17 which broke the types declared in this plugin. I can't find anything in the PR or commit message that explains why this was done, but this module does not have a default export.

Fixes: #260 