### PR TITLE
Copy response description from schema

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -285,6 +285,10 @@ module.exports = function (fastify, opts, next) {
           responsesContainer[key] = {
             schema: resolved
           }
+          if (resolved.description) {
+            responsesContainer[key].description = resolved.description
+            delete resolved.description
+          }
         } else {
           responsesContainer[key] = resolved
         }

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -441,7 +441,7 @@ test('deprecated route', t => {
 })
 
 test('route meta info', t => {
-  t.plan(8)
+  t.plan(9)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerInfo)
@@ -453,7 +453,8 @@ test('route meta info', t => {
       tags: ['tag'],
       description: 'Route description',
       produces: ['application/octet-stream'],
-      consumes: ['application/x-www-form-urlencoded']
+      consumes: ['application/x-www-form-urlencoded'],
+      response: { 200: { type: 'object', description: 'Success description' } }
     }
   }
 
@@ -473,6 +474,7 @@ test('route meta info', t => {
         t.equal(opts.schema.description, definedPath.description)
         t.same(opts.schema.produces, definedPath.produces)
         t.same(opts.schema.consumes, definedPath.consumes)
+        t.same(opts.schema.response[200].description, definedPath.responses[200].description)
       })
       .catch(function (err) {
         t.fail(err)


### PR DESCRIPTION
Fastify defines response description using `route.schema.response.${code}.description` and Swagger uses `route.responses.${code}.description`.

This PR copies `description` property from `schema` to "response code" object and removes it from `schema`. This works only if the response has a `type` or `$ref` property, avoiding to *always* fill with "Default Response".

https://swagger.io/docs/specification/describing-responses/#body

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
