### PR TITLE
Adds better support for TS and ES modules imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,8 @@ declare module 'fastify' {
 
 type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
 
-declare const fastifySwagger: FastifyPlugin<SwaggerOptions>
+declare const fastifySwagger: FastifyPlugin<SwaggerOptions> & {
+  default: FastifyPlugin<SwaggerOptions>;
+};
 
 export = fastifySwagger;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ function fastifySwagger (fastify, opts, next) {
   }
 }
 
-module.exports = fp(fastifySwagger, {
+const plugin = fp(fastifySwagger, {
   fastify: '>=3.x',
   name: 'fastify-swagger'
 })
+
+plugin.default = fastifySwagger
+
+module.exports = plugin

--- a/test/default-export.js
+++ b/test/default-export.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const Swagger = require('swagger-parser')
+const fastifySwagger = require('../index')
+
+const swaggerInfo = {
+  swagger: {
+    info: {
+      title: 'Test swagger',
+      description: 'testing the fastify swagger api',
+      version: '0.1.0'
+    },
+    host: 'localhost',
+    schemes: ['http'],
+    consumes: ['application/json'],
+    produces: ['application/json'],
+    securityDefinitions: {
+      apiKey: {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'header'
+      }
+    }
+  },
+  exposeRoute: true
+}
+
+test('/documentation/json route default export', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger.default, swaggerInfo)
+
+  fastify.get('/', () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  }, (err, res) => {
+    t.error(err)
+
+    var payload = JSON.parse(res.payload)
+
+    Swagger.validate(payload)
+      .then(function (api) {
+        t.pass('valid swagger object')
+      })
+      .catch(function (err) {
+        t.fail(err)
+      })
+  })
+})

--- a/test/types/check-default-export.ts
+++ b/test/types/check-default-export.ts
@@ -1,0 +1,6 @@
+import { expectAssignable } from 'tsd';
+
+import fastifySwagger from '../..';
+import * as fastifySwaggerNamespace from '../..';
+
+expectAssignable<typeof fastifySwagger>(fastifySwaggerNamespace);

--- a/test/types/check-default-export.ts
+++ b/test/types/check-default-export.ts
@@ -2,5 +2,7 @@ import { expectAssignable } from 'tsd';
 
 import fastifySwagger from '../..';
 import * as fastifySwaggerNamespace from '../..';
+import fastifySwaggerRequired = require('../..')
 
 expectAssignable<typeof fastifySwagger>(fastifySwaggerNamespace);
+expectAssignable<typeof fastifySwaggerRequired>(fastifySwaggerNamespace);

--- a/test/types/http2-types.test.ts
+++ b/test/types/http2-types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger = require('../..');
+import fastifySwagger from '../..';
 
 const app = fastify({
   http2: true

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger = require('../..');
+import * as fastifySwagger from '../..';
 
 const app = fastify();
 


### PR DESCRIPTION
Hi, I am opening this PR in order to show what has been discussed here: https://github.com/fastify/fastify/issues/2403#issuecomment-659311897
Here we support all of the cases that are show in that issue. 
For the TS side:
1. `import * as fastifySwagger from 'fastify-swagger'` 
2. `import fastifySwagger from 'fastify-swagger'`: this works thanks to adding `.default` export to `module.exports` on JS side.
3. the "deprecated" `import fastifySwagger= require('fastify-swagger)`

On the JS side it adds `.default` property to the `module.exports` in order to support also ES default imports.

We can use this PR to further check if this can fit for Fastify's ecosystem and find potential bugs and quirks.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
