### PR TITLE
Export ts types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ interface FastifySwaggerOptions {
   exposeRoute?: boolean;
 }
 
-interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
+export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
   mode?: 'dynamic';
   swagger?: Partial<SwaggerSchema.Spec>;
   /**
@@ -34,7 +34,7 @@ interface StaticDocumentSpec {
   document: string;
 }
 
-interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
+export interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
   mode: 'static';
   specification: StaticPathSpec | StaticDocumentSpec;
 }
@@ -58,7 +58,7 @@ declare module 'fastify' {
   }
 }
 
-type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
+export type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
 
 declare const fastifySwagger: FastifyPlugin<SwaggerOptions>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,44 +1,6 @@
 import { FastifyPlugin } from 'fastify';
 import * as SwaggerSchema from 'swagger-schema-official';
 
-interface FastifySwaggerOptions {
-  mode?: 'static' | 'dynamic';
-  /**
-   * Overwrite the swagger url end-point
-   * @default /documentation
-   */
-  routePrefix?: string;
-  /**
-   * To expose the documentation api
-   * @default false
-   */
-  exposeRoute?: boolean;
-}
-
-export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
-  mode?: 'dynamic';
-  swagger?: Partial<SwaggerSchema.Spec>;
-  /**
-   * Overwrite the route schema
-   */
-  transform?: Function;
-}
-
-interface StaticPathSpec {
-  path: string;
-  postProcessor?: (spec: SwaggerSchema.Spec) => SwaggerSchema.Spec;
-  baseDir: string;
-}
-
-interface StaticDocumentSpec {
-  document: string;
-}
-
-export interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
-  mode: 'static';
-  specification: StaticPathSpec | StaticDocumentSpec;
-}
-
 declare module 'fastify' {
   interface FastifyInstance {
     swagger: (
@@ -58,8 +20,48 @@ declare module 'fastify' {
   }
 }
 
-export type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
+declare const fastifySwagger: FastifyPlugin<fastifySwagger.SwaggerOptions>
+ 
+declare namespace fastifySwagger {
+  type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
 
-declare const fastifySwagger: FastifyPlugin<SwaggerOptions>
+  interface FastifySwaggerOptions {
+    mode?: 'static' | 'dynamic';
+    /**
+     * Overwrite the swagger url end-point
+     * @default /documentation
+     */
+    routePrefix?: string;
+    /**
+     * To expose the documentation api
+     * @default false
+     */
+    exposeRoute?: boolean;
+  }
+  
+  interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
+    mode?: 'dynamic';
+    swagger?: Partial<SwaggerSchema.Spec>;
+    /**
+     * Overwrite the route schema
+     */
+    transform?: Function;
+  }
+  
+  interface StaticPathSpec {
+    path: string;
+    postProcessor?: (spec: SwaggerSchema.Spec) => SwaggerSchema.Spec;
+    baseDir: string;
+  }
+  
+  interface StaticDocumentSpec {
+    document: string;
+  }
+  
+  interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
+    mode: 'static';
+    specification: StaticPathSpec | StaticDocumentSpec;
+  }
+}
 
 export = fastifySwagger;

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify';
 import fastifySwagger = require('../..');
+import { SwaggerOptions } from '../..'
 
 const app = fastify();
 
@@ -14,6 +15,16 @@ app.register(fastifySwagger, {
   routePrefix: '/documentation',
   exposeRoute: true,
 });
+
+const fastifySwaggerOptions: SwaggerOptions = {
+  mode: 'static',
+  specification: {
+    document: 'path'
+  },
+  routePrefix: '/documentation',
+  exposeRoute: true,
+}
+app.register(fastifySwagger, fastifySwaggerOptions);
 
 app.put('/some-route/:id', {
     schema: {


### PR DESCRIPTION
Make FastifyDynamicSwaggerOptions, FastifyStaticSwaggerOptions & SwaggerOptions exported for cases like:

```ts
import fastifySwagger, { SwaggerOptions } from 'fastify-swagger'

const options: SwaggerOptions = {
  ...
}

app.register(fastifySwagger, options)
```

 This was possible in v2