### PR TITLE
Adds the "infamous triplet" and exports default and names exports in TypeScript types

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,5 @@
+esm: false
+ts: false
+jsx: false
+flow: false
+coverage: true

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,49 +20,46 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifySwagger: FastifyPlugin<fastifySwagger.SwaggerOptions>
+export const fastifySwagger: FastifyPlugin<SwaggerOptions>;
  
-declare namespace fastifySwagger {
-  type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions)
-
-  interface FastifySwaggerOptions {
-    mode?: 'static' | 'dynamic';
-    /**
-     * Overwrite the swagger url end-point
-     * @default /documentation
-     */
-    routePrefix?: string;
-    /**
-     * To expose the documentation api
-     * @default false
-     */
-    exposeRoute?: boolean;
-  }
-  
-  interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
-    mode?: 'dynamic';
-    swagger?: Partial<SwaggerSchema.Spec>;
-    hiddenTag?: string;
-    /**
-     * Overwrite the route schema
-     */
-    transform?: Function;
-  }
-  
-  interface StaticPathSpec {
-    path: string;
-    postProcessor?: (spec: SwaggerSchema.Spec) => SwaggerSchema.Spec;
-    baseDir: string;
-  }
-  
-  interface StaticDocumentSpec {
-    document: string;
-  }
-  
-  interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
-    mode: 'static';
-    specification: StaticPathSpec | StaticDocumentSpec;
-  }
+export type SwaggerOptions = (FastifyStaticSwaggerOptions | FastifyDynamicSwaggerOptions);
+export interface FastifySwaggerOptions {
+  mode?: 'static' | 'dynamic';
+  /**
+   * Overwrite the swagger url end-point
+   * @default /documentation
+   */
+  routePrefix?: string;
+  /**
+   * To expose the documentation api
+   * @default false
+   */
+  exposeRoute?: boolean;
 }
 
-export = fastifySwagger;
+export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
+  mode?: 'dynamic';
+  swagger?: Partial<SwaggerSchema.Spec>;
+  hiddenTag?: string;
+  /**
+   * Overwrite the route schema
+   */
+  transform?: Function;
+}
+
+export interface StaticPathSpec {
+  path: string;
+  postProcessor?: (spec: SwaggerSchema.Spec) => SwaggerSchema.Spec;
+  baseDir: string;
+}
+
+export interface StaticDocumentSpec {
+  document: string;
+}
+
+export interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {
+  mode: 'static';
+  specification: StaticPathSpec | StaticDocumentSpec;
+}
+
+export default fastifySwagger;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ function fastifySwagger (fastify, opts, next) {
   }
 }
 
-module.exports = fp(fastifySwagger, {
+const fastifySwaggerPlugin = fp(fastifySwagger, {
   fastify: '>=3.x',
   name: 'fastify-swagger'
 })
+
+module.exports = fastifySwaggerPlugin
+module.exports.default = fastifySwaggerPlugin
+module.exports.fastifySwagger = fastifySwaggerPlugin

--- a/index.js
+++ b/index.js
@@ -22,11 +22,7 @@ function fastifySwagger (fastify, opts, next) {
   }
 }
 
-const fastifySwaggerPlugin = fp(fastifySwagger, {
+module.exports = fp(fastifySwagger, {
   fastify: '>=3.x',
   name: 'fastify-swagger'
 })
-
-module.exports = fastifySwaggerPlugin
-module.exports.default = fastifySwaggerPlugin
-module.exports.fastifySwagger = fastifySwaggerPlugin

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@types/swagger-schema-official": "^2.0.20",
-    "fastify-plugin": "^2.0.0",
+    "fastify-plugin": "^2.3.0",
     "fastify-static": "^3.0.0",
     "js-yaml": "^3.14.0",
     "json-schema-resolver": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prepare": "node prepare-swagger-ui",
-    "test": "standard && tap --100 test/*.js && npm run typescript",
+    "test": "standard && tap --no-esm --100 test/*.js test/esm/*.js && npm run typescript",
     "prepublishOnly": "npm run prepare",
     "typescript": "tsd"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prepare": "node prepare-swagger-ui",
-    "test": "standard && tap --no-esm --100 test/*.js test/esm/*.js && npm run typescript",
+    "test": "standard && tap --100 test/*.js test/esm/*.js && npm run typescript",
     "prepublishOnly": "npm run prepare",
     "typescript": "tsd"
   },

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -1,0 +1,14 @@
+import t from 'tap'
+import Fastify from 'fastify'
+import swaggerDefault from '../../index.js'
+
+t.test('esm support', async t => {
+  const fastify = Fastify()
+
+  fastify.register(swaggerDefault)
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  t.equal(swaggerObject.swagger, '2.0')
+})

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const t = require('tap')
+const semver = require('semver')
+
+if (semver.lt(process.versions.node, '13.3.0')) {
+  t.skip('Skip because Node version <= 13.3.0')
+  t.end()
+} else {
+  // Node v8 throw a `SyntaxError: Unexpected token import`
+  // even if this branch is never touch in the code,
+  // by using `eval` we can avoid this issue.
+  // eslint-disable-next-line
+  new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
+    process.nextTick(() => {
+      throw err
+    })
+  })
+}

--- a/test/types/http2-types.test.ts
+++ b/test/types/http2-types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger = require('../..');
+import fastifySwagger from '../..';
 
 const app = fastify({
   http2: true

--- a/test/types/imports.test.ts
+++ b/test/types/imports.test.ts
@@ -1,0 +1,23 @@
+import fastify from "fastify";
+
+import swaggerDefault, { fastifySwagger, SwaggerOptions } from "../..";
+import * as fastifySwaggerStar from "../..";
+
+const app = fastify();
+const fastifySwaggerOptions: SwaggerOptions = {
+  mode: "static",
+  specification: {
+    document: "path",
+  },
+  routePrefix: "/documentation",
+  exposeRoute: true,
+};
+
+app.register(swaggerDefault, fastifySwaggerOptions);
+app.register(fastifySwagger, fastifySwaggerOptions);
+app.register(fastifySwaggerStar.default, fastifySwaggerOptions);
+app.register(fastifySwaggerStar.fastifySwagger, fastifySwaggerOptions);
+
+app.ready((err) => {
+  app.swagger();
+});

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,6 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger = require('../..');
-import { SwaggerOptions } from '../..'
+import fastifySwagger, { SwaggerOptions } from '../..';
 
 const app = fastify();
 


### PR DESCRIPTION
This PR is the result of the ongoing talks about supporting all import contexts for the fastify ecosystem. We can use it as a case study for other core plugins.

What is important to note is that it is not enough to add this code only at JS, since the exported typings need to be updated too.

- Adds the "infamous triplet" in `module.exports`
- Replaces namespace export with "infamous triplet" in TypeScript typings
- Adds test for all TS imports
- Adds test for ESM context

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
