### PR TITLE
use the response schema's custom description if present

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -285,7 +285,7 @@ module.exports = function (fastify, opts, next) {
 
         responsesContainer[key] = {
           schema: resolved,
-          description: 'Default Response'
+          description: rawJsonSchema.description || 'Default Response'
         }
       })
 


### PR DESCRIPTION
Previously, the response schema's description was ignored (though it was present in fastify-swagger examples, it was not shown on the generated documentation webpage). Now, instead of always showing "Default Response" we show the value of the `description` field, if provided.