### PR TITLE
Fix bug #299 Response description prop is not appended correctly to schema definition

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -285,7 +285,7 @@ module.exports = function (fastify, opts, next) {
 
         responsesContainer[key] = {
           schema: resolved,
-          description: 'Default Response'
+          description: rawJsonSchema.description || 'Default Response'
         }
       })
 

--- a/test/json-schema.test.js
+++ b/test/json-schema.test.js
@@ -106,3 +106,58 @@ test('support file in json schema', async t => {
     type: 'file'
   }])
 })
+
+test('support response description', async t => {
+  const opts8 = {
+    schema: {
+      response: {
+        200: {
+          description: 'Response OK!',
+          type: 'object'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opts8, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['200'].description, 'Response OK!')
+})
+
+test('response default description', async t => {
+  const opts9 = {
+    schema: {
+      response: {
+        200: {
+          type: 'object'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opts9, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['200'].description, 'Default Response')
+})


### PR DESCRIPTION
Added support for description in response keys (status code) 

Like this example (present in bug #299):

```javascript
response: {
  200: {
    type: 'object',
    properties: {
      hello: { type: 'string' },
    },
    description: 'some description'
  }
}
```