### PR TITLE
fix: include swagger extensions if define at the root

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -47,6 +47,13 @@ module.exports = function (fastify, opts, next) {
   const externalDocs = opts.swagger.externalDocs || null
   const transform = opts.transform || null
   const hiddenTag = opts.hiddenTag || 'X-HIDDEN'
+  const extensions = []
+
+  for (const [key, value] of Object.entries(opts.swagger)) {
+    if (key.startsWith('x-')) {
+      extensions.push([key, value])
+    }
+  }
 
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'
@@ -105,6 +112,10 @@ module.exports = function (fastify, opts, next) {
     }
     if (externalDocs) {
       swaggerObject.externalDocs = externalDocs
+    }
+
+    for (const [key, value] of extensions) {
+      swaggerObject[key] = value
     }
 
     const externalSchemas = Array.from(sharedSchemasMap.values())

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -589,9 +589,9 @@ test('parses form parameters when all api consumes application/x-www-form-urlenc
 })
 
 test('includes swagger extensions', t => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerInfo)
+  fastify.register(fastifySwagger, { swagger: { 'x-ternal': true } })
   fastify.get('/', opts8, () => {})
 
   fastify.ready(err => {
@@ -600,6 +600,9 @@ test('includes swagger extensions', t => {
 
     Swagger.validate(swaggerObject)
       .then(function (api) {
+        t.ok(api['x-ternal'])
+        t.same(api['x-ternal'], true)
+
         const definedPath = api.paths['/'].get
         t.ok(definedPath)
         t.same(definedPath['x-tension'], true)


### PR DESCRIPTION
Fixes #304, but I'm not super fan of the implementation. 

I'm missing an update on the type definitions, but I can't express `Partial<SwaggerSchema.Spec>` and properties starting by `x-`. Do you have any preferences about what to do with that? 