### PR TITLE
feature: when `stripBasePath` is set to false, do not strip basePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,15 @@ fastify.ready(err => {
   Example of the `fastify-swagger` usage in the `dynamic` mode is available [here](examples/dynamic.js).
 <a name="mode.static"></a>
 
-  If you would like to maintain your basePath setting without it being removed from your routes, you can set the `FASTIFY_SWAGGER_LEAVE_BASE_PATH` environment
-  variable to a truthy value.
+##### options
+
+ | option        | default  | description                           |
+ |---------------|----------|---------------------------------------|
+ | exposeRoute   | false    | Exposes documentation route.          |
+ | hiddenTag     | X-HIDDEN | Tag to control hiding of routes.      |
+ | stripBasePath | true     | Strips base path from routes in docs. |
+ | swagger       | {}       | Swagger configuration.                |
+ | transform     | null     | Transform method for schema.          |
 
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
@@ -179,7 +186,6 @@ If you pass `{ exposeRoute: true }` during the registration the plugin will expo
 |`'/documentation/yaml'` | the yaml object representing the api  |
 |`'/documentation/'` | the swagger ui  |
 |`'/documentation/*'`| external files which you may use in `$ref`|
-
 
 ##### Overwrite swagger url end-point
 If you would like to overwrite the `/documentation` url you can use the `routePrefix` option.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ fastify.ready(err => {
   Example of the `fastify-swagger` usage in the `dynamic` mode is available [here](examples/dynamic.js).
 <a name="mode.static"></a>
 
+  If you would like to maintain your basePath setting without it being removed from your routes, you can set the `FASTIFY_SWAGGER_LEAVE_BASE_PATH` environment
+  variable to a truthy value.
+
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
   ```js

--- a/dynamic.js
+++ b/dynamic.js
@@ -30,9 +30,13 @@ module.exports = function (fastify, opts, next) {
     })
   })
 
-  opts = opts || {}
-
-  opts.swagger = opts.swagger || {}
+  opts = Object.assign({}, {
+    exposeRoute: false,
+    hiddenTag: 'X-HIDDEN',
+    stripBasePath: true,
+    swagger: {},
+    transform: null
+  }, opts || {})
 
   const info = opts.swagger.info || null
   const host = opts.swagger.host || null
@@ -45,8 +49,9 @@ module.exports = function (fastify, opts, next) {
   const security = opts.swagger.security || null
   const tags = opts.swagger.tags || null
   const externalDocs = opts.swagger.externalDocs || null
-  const transform = opts.transform || null
-  const hiddenTag = opts.hiddenTag || 'X-HIDDEN'
+  const stripBasePath = opts.stripBasePath
+  const transform = opts.transform
+  const hiddenTag = opts.hiddenTag
 
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'
@@ -134,7 +139,7 @@ module.exports = function (fastify, opts, next) {
       const schema = transform
         ? transform(route.schema)
         : route.schema
-      let path = route.url.startsWith(basePath) && !process.env.FASTIFY_SWAGGER_LEAVE_BASE_PATH
+      let path = stripBasePath && route.url.startsWith(basePath)
         ? route.url.replace(basePath, '')
         : route.url
       if (!path.startsWith('/')) {

--- a/dynamic.js
+++ b/dynamic.js
@@ -134,7 +134,7 @@ module.exports = function (fastify, opts, next) {
       const schema = transform
         ? transform(route.schema)
         : route.schema
-      let path = route.url.startsWith(basePath)
+      let path = route.url.startsWith(basePath) && !process.env.FASTIFY_SWAGGER_LEAVE_BASE_PATH
         ? route.url.replace(basePath, '')
         : route.url
       if (!path.startsWith('/')) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,11 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
   swagger?: Partial<SwaggerSchema.Spec>;
   hiddenTag?: string;
   /**
+   * Strips matching base path from routes in documentation
+   * @default true
+   */
+  stripBasePath?: boolean;
+  /**
    * Overwrite the route schema
    */
   transform?: Function;

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -783,3 +783,28 @@ test('basePath with prefix ensure leading slash', t => {
     t.ok(swaggerObject.paths['/endpoint'])
   })
 })
+
+test('basePath maintained when FASTIFY_SWAGGER_LEAVE_BASE_PATH environment variable is set', t => {
+  t.plan(4)
+
+  process.env.FASTIFY_SWAGGER_LEAVE_BASE_PATH = true
+
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    swagger: Object.assign({}, swaggerInfo.swagger, {
+      basePath: '/foo'
+    })
+  })
+
+  fastify.get('/foo/endpoint', {}, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths.endpoint)
+    t.notOk(swaggerObject.paths['/endpoint'])
+    t.ok(swaggerObject.paths['/foo/endpoint'])
+  })
+})

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -784,14 +784,13 @@ test('basePath with prefix ensure leading slash', t => {
   })
 })
 
-test('basePath maintained when FASTIFY_SWAGGER_LEAVE_BASE_PATH environment variable is set', t => {
+test('basePath maintained when stripBasePath is set to false', t => {
   t.plan(4)
-
-  process.env.FASTIFY_SWAGGER_LEAVE_BASE_PATH = true
 
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, {
+    stripBasePath: false,
     swagger: Object.assign({}, swaggerInfo.swagger, {
       basePath: '/foo'
     })

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -25,6 +25,14 @@ const fastifySwaggerOptions: SwaggerOptions = {
 }
 app.register(fastifySwagger, fastifySwaggerOptions);
 
+const fastifyDynamicSwaggerOptions: SwaggerOptions = {
+  mode: 'dynamic',
+  routePrefix: '/documentation',
+  exposeRoute: true,
+  stripBasePath: true
+}
+app.register(fastifySwagger, fastifyDynamicSwaggerOptions);
+
 app.put('/some-route/:id', {
     schema: {
       description: 'put me some data',


### PR DESCRIPTION
Related to #232 #233

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
