### PR TITLE
fix: execute transform(schema) before checking schema.hide and hiddenTag

### DIFF
--- a/dynamic.js
+++ b/dynamic.js
@@ -123,17 +123,18 @@ module.exports = function (fastify, opts, next) {
 
     swaggerObject.paths = {}
     for (var route of routes) {
-      if (route.schema && route.schema.hide) {
-        continue
-      }
-
-      if (route.schema && route.schema.tags && route.schema.tags.includes(hiddenTag)) {
-        continue
-      }
-
       const schema = transform
         ? transform(route.schema)
         : route.schema
+
+      if (schema && schema.hide) {
+        continue
+      }
+
+      if (schema && schema.tags && schema.tags.includes(hiddenTag)) {
+        continue
+      }
+
       let path = route.url.startsWith(basePath)
         ? route.url.replace(basePath, '')
         : route.url

--- a/test/swagger.js
+++ b/test/swagger.js
@@ -411,6 +411,44 @@ test('hide support - property', t => {
   })
 })
 
+test('hide support when property set in transform() - property', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    ...swaggerInfo,
+    transform: schema => {
+      return { ...schema, hide: true }
+    }
+  })
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' },
+          obj: {
+            type: 'object',
+            properties: {
+              some: { type: 'string' }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths['/'])
+  })
+})
+
 test('hide support - tags Default', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
Linked to issue https://github.com/fastify/fastify-swagger/issues/316

#### Checklist

- [x] run `npm run test`
- [x] commit message and code follows the guidelines

No need to update the doc as this is the expected behaviour of what's currently described in the section about hiding routes