### PR TITLE
add operationId to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,10 @@ declare module 'fastify' {
     summary?: string;
     consumes?: string[];
     security?: Array<{ [securityLabel: string]: string[] }>;
+    /**
+     * OpenAPI operation unique identifier
+     */
+    operationId?: string;    
   }
 }
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -39,7 +39,8 @@ app.put('/some-route/:id', {
       tags: ['user', 'code'],
       summary: 'qwerty',
       consumes: ['application/json', 'multipart/form-data'],
-      security: [{ apiKey: []}]
+      security: [{ apiKey: []}],
+      operationId: 'opeId',
     }
   }, (req, reply) => {});
 


### PR DESCRIPTION
OperationId is handled in the code [here](https://github.com/fastify/fastify-swagger/blob/master/dynamic.js#L166) but not in the ts types.

This Pull request add the operationId field to the `FastifySchema` type.

`operationId` is described here : https://swagger.io/docs/specification/paths-and-operations/

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
