### PR TITLE
Fix type of StaticDocumentSpec.document in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { FastifyPlugin } from 'fastify';
 import * as SwaggerSchema from 'swagger-schema-official';
+import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -68,7 +69,7 @@ export interface StaticPathSpec {
 }
 
 export interface StaticDocumentSpec {
-  document: string;
+  document: OpenAPIV2.Document | OpenAPIV3.Document;
 }
 
 export interface FastifyStaticSwaggerOptions extends FastifySwaggerOptions {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^9.0.0",
     "joi": "^14.3.1",
     "joi-to-json-schema": "^5.1.0",
+    "openapi-types": "^7.0.1",
     "pre-commit": "^1.2.2",
     "standard": "^16.0.1",
     "swagger-parser": "^10.0.2",

--- a/test/types/http2-types.test.ts
+++ b/test/types/http2-types.test.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify';
 import fastifySwagger from '../..';
+import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 
 const app = fastify({
   http2: true
@@ -11,7 +12,7 @@ app.register(fastifySwagger, { transform: (schema : any) => schema });
 app.register(fastifySwagger, {
   mode: 'static',
   specification: {
-    document: 'path'
+    document: minimalOpenApiV3Document
   },
   routePrefix: '/documentation',
   exposeRoute: true,

--- a/test/types/imports.test.ts
+++ b/test/types/imports.test.ts
@@ -2,12 +2,13 @@ import fastify from "fastify";
 
 import swaggerDefault, { fastifySwagger, SwaggerOptions } from "../..";
 import * as fastifySwaggerStar from "../..";
+import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 
 const app = fastify();
 const fastifySwaggerOptions: SwaggerOptions = {
   mode: "static",
   specification: {
-    document: "path",
+    document: minimalOpenApiV3Document,
   },
   routePrefix: "/documentation",
   exposeRoute: true,

--- a/test/types/minimal-openapiV3-document.ts
+++ b/test/types/minimal-openapiV3-document.ts
@@ -1,0 +1,11 @@
+import { OpenAPIV3 } from 'openapi-types'
+
+export const minimalOpenApiV3Document: OpenAPIV3.Document = {
+  openapi: '3.0.0',
+  info: {
+    "version": "1.0.0",
+    "title": "Test OpenApiv3 specification",
+  },
+  "paths": {
+  }
+}

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify';
 import fastifySwagger, { SwaggerOptions } from '../..';
+import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 
 const app = fastify();
 
@@ -9,7 +10,7 @@ app.register(fastifySwagger, { transform: (schema : any) => schema });
 app.register(fastifySwagger, {
   mode: 'static',
   specification: {
-    document: 'path'
+    document: minimalOpenApiV3Document
   },
   routePrefix: '/documentation',
   exposeRoute: true,
@@ -18,7 +19,7 @@ app.register(fastifySwagger, {
 const fastifySwaggerOptions: SwaggerOptions = {
   mode: 'static',
   specification: {
-    document: 'path'
+    document: minimalOpenApiV3Document
   },
   routePrefix: '/documentation',
   exposeRoute: true,


### PR DESCRIPTION
Closes #327

The type of the property 'document' in the interface StaticDocumentSpec in the file 'index.d.ts' was formerly specified as 'string' and was corrected to object.

I think one could even specify it as one of
 - SwaggerSchema.Spec (for swagger V2 specs -already imported) or
 - OpenApi3Spec (for OpenApi V3 specs - where can this come from?)

Are there other versions that would then need to be supported?


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
