### PR TITLE
Transform Fastify schema.responseDescription to OAS response.description  [#336]

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ fastify.ready(err => {
 
   fastify-swagger will generate Swagger v2 by default. If you pass the `opeanapi` option it will generate OpenAPI instead.
 
-  Example of the `fastify-swagger` usage in the `dynamic` mode, `swagger` option is available [here](examples/dynamic-swagger.js) and `openapi` option is avaiable [here](examples/dynamic-openapi.js).
+  Example of the `fastify-swagger` usage in the `dynamic` mode, `swagger` option is available [here](examples/dynamic-swagger.js) and `openapi` option is available [here](examples/dynamic-openapi.js).
 
 ##### options
 
@@ -182,6 +182,183 @@ fastify.ready(err => {
  | uiConfig*     | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
 
 > `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
+
+<a name="response.description"></a>
+##### response description and response body description
+If you do not supply a `description` for your response, a default description will be provided for you, because this is a required field per the Swagger schema.
+
+So this:
+
+```js
+fastify.get('/defaultDescription', {
+    schema: {
+      response: {
+        200: {
+          type: 'string'
+        }
+      }
+    }
+  }, () => {})
+```
+
+Generates this in the Swagger (OAS2) schema's `paths`:
+
+```json
+{
+  "/defaultDescription": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "Default Response",
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And this in the OAS 3 schema's `paths`:
+
+```
+{
+  "/defaultDescription": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "Default Response",
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If you do supply just a `description`, it will be used both for the response as a whole and for the response body schema.
+
+So this:
+
+```js
+fastify.get('/description', {
+  schema: {
+    response: {
+      200: {
+        description: 'response and schema description',
+        type: 'string'
+      }
+    }
+  }
+}, () => {})
+```
+
+Generates this in the Swagger (OAS2) schema's `paths`:
+
+```json
+{
+  "/description": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "response and schema description",
+          "schema": {
+            "description": "response and schema description",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And this in the OAS 3 schema's `paths`:
+
+```json
+{
+  "/description": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "response and schema description",
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "response and schema description",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If you want to provide a different description for the response as a whole, instead use the `responseDescription` field alongside `description`:
+
+```js
+fastify.get('/responseDescription', {
+  schema: {
+    response: {
+      200: {
+        responseDescription: 'response description',
+        description: 'schema description',
+        type: 'string'
+      }
+    }
+  }
+}, () => {})
+```
+
+Which generates this in the Swagger (OAS2) schema's `paths`:
+
+```json
+{
+  "/responseDescription": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "response description",
+          "schema": {
+            "description": "schema description",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And this in the OAS 3 schema's `paths`:
+
+```json
+{
+  "/responseDescription": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "response description",
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "schema description",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ##### 2XX status code
 `fastify` itself support the `2xx`, `3xx` status, however `swagger` itself do not support this featuer. We will help you to transform the `2xx` status code into `200` and we will omit `2xx` status code when you already declared `200` status code.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ fastify.ready(err => {
   fastify-swagger will generate Swagger v2 by default. If you pass the `opeanapi` option it will generate OpenAPI instead.
 
   Example of the `fastify-swagger` usage in the `dynamic` mode, `swagger` option is available [here](examples/dynamic-swagger.js) and `openapi` option is avaiable [here](examples/dynamic-openapi.js).
-<a name="mode.static"></a>
 
 ##### options
 
@@ -228,7 +227,7 @@ You can decorate your own response headers by follow the below example.
   }
 }
 ```
-Note: You need to specify `type` property when you decorate the response headers, otherwise the schema will be modify by `fastify`.
+Note: You need to specify `type` property when you decorate the response headers, otherwise the schema will be modified by `fastify`.
 
 ##### status code 204
 We support status code 204 and return empty body. Please specify `type: 'null'` for the response otherwise `fastify` itself will fail to compile the schema.
@@ -243,6 +242,7 @@ We support status code 204 and return empty body. Please specify `type: 'null'` 
 }
 ```
 
+<a name="mode.static"></a>
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
   ```js
@@ -400,7 +400,7 @@ You can integration this plugin with ```fastify-helmet``` with some little work.
     }
   }
 })
-``` 
+```
 
 <a name="security"></a>
 ### Security

--- a/README.md
+++ b/README.md
@@ -300,14 +300,14 @@ And this in the OAS 3 schema's `paths`:
 }
 ```
 
-If you want to provide a different description for the response as a whole, instead use the `responseDescription` field alongside `description`:
+If you want to provide a different description for the response as a whole, instead use the `x-response-description` field alongside `description`:
 
 ```js
 fastify.get('/responseDescription', {
   schema: {
     response: {
       200: {
-        responseDescription: 'response description',
+        'x-response-description': 'response description',
         description: 'schema description',
         type: 'string'
       }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -176,7 +176,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
     statusCode = statusCode.toUpperCase()
 
     const response = {
-      description: rawJsonSchema.description || 'Default Response'
+      description: resolved.responseDescription || rawJsonSchema.description || 'Default Response'
     }
 
     // add headers when there are any.
@@ -206,6 +206,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
         produces = ['application/json']
       }
 
+      delete resolved.responseDescription
       produces.forEach((produce) => {
         content[produce] = {
           schema: resolved

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -176,7 +176,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
     statusCode = statusCode.toUpperCase()
 
     const response = {
-      description: resolved.responseDescription || rawJsonSchema.description || 'Default Response'
+      description: resolved['x-response-description'] || rawJsonSchema.description || 'Default Response'
     }
 
     // add headers when there are any.
@@ -206,7 +206,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
         produces = ['application/json']
       }
 
-      delete resolved.responseDescription
+      delete resolved['x-response-description']
       produces.forEach((produce) => {
         content[produce] = {
           schema: resolved

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -194,7 +194,7 @@ function resolveResponse (fastifyResponseJson, ref) {
     statusCode = deXXStatusCode
 
     const response = {
-      description: rawJsonSchema.responseDescription || rawJsonSchema.description || 'Default Response'
+      description: rawJsonSchema['x-response-description'] || rawJsonSchema.description || 'Default Response'
     }
 
     // add headers when there are any.
@@ -207,7 +207,7 @@ function resolveResponse (fastifyResponseJson, ref) {
     // add schema when status code is not 204
     if (statusCode.toString() !== '204') {
       const schema = { ...resolved }
-      delete schema.responseDescription
+      delete schema['x-response-description']
       response.schema = schema
     }
 

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -194,7 +194,7 @@ function resolveResponse (fastifyResponseJson, ref) {
     statusCode = deXXStatusCode
 
     const response = {
-      description: rawJsonSchema.description || 'Default Response'
+      description: rawJsonSchema.responseDescription || rawJsonSchema.description || 'Default Response'
     }
 
     // add headers when there are any.
@@ -206,7 +206,9 @@ function resolveResponse (fastifyResponseJson, ref) {
 
     // add schema when status code is not 204
     if (statusCode.toString() !== '204') {
-      response.schema = resolved
+      const schema = { ...resolved }
+      delete schema.responseDescription
+      response.schema = schema
     }
 
     responsesContainer[statusCode] = response

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -156,11 +156,11 @@ test('support response headers', async t => {
   t.notOk(definedPath.responses['200'].content['application/json'].schema.headers)
 })
 
-test('response: description and responseDescription', async () => {
+test('response: description and x-response-description', async () => {
   const description = 'description - always that of response body, sometimes also that of response as a whole'
   const responseDescription = 'description only for the response as a whole'
 
-  test('description without responseDescription doubles as responseDescription', async t => {
+  test('description without x-response-description doubles as response description', async t => {
     // Given a /description endpoint with only a |description| field in its response schema
     const fastify = Fastify()
     fastify.register(fastifySwagger, openapiOption)
@@ -191,15 +191,15 @@ test('response: description and responseDescription', async () => {
     t.equal(schemaObject.description, description)
   })
 
-  test('description alongside responseDescription only describes response body', async t => {
-    // Given a /responseDescription endpoint that also has a |responseDescription| field in its response schema
+  test('description alongside x-response-description only describes response body', async t => {
+    // Given a /x-response-description endpoint that also has a |x-response-description| field in its response schema
     const fastify = Fastify()
     fastify.register(fastifySwagger, openapiOption)
     fastify.get('/responseDescription', {
       schema: {
         response: {
           200: {
-            responseDescription,
+            'x-response-description': responseDescription,
             description,
             type: 'string'
           }

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -155,3 +155,71 @@ test('support response headers', async t => {
   })
   t.notOk(definedPath.responses['200'].content['application/json'].schema.headers)
 })
+
+test('response: description and responseDescription', async () => {
+  const description = 'description - always that of response body, sometimes also that of response as a whole'
+  const responseDescription = 'description only for the response as a whole'
+
+  test('description without responseDescription doubles as responseDescription', async t => {
+    // Given a /description endpoint with only a |description| field in its response schema
+    const fastify = Fastify()
+    fastify.register(fastifySwagger, openapiOption)
+    fastify.get('/description', {
+      schema: {
+        response: {
+          200: {
+            description,
+            type: 'string'
+          }
+        }
+      }
+    }, () => {})
+    await fastify.ready()
+
+    // When the Swagger schema is generated
+    const swaggerObject = fastify.swagger()
+    const api = await Swagger.validate(swaggerObject)
+
+    // Then the /description endpoint uses the |description| as both the description of the Response Object as well as of its Schema Object
+    /** @type {import('openapi-types').OpenAPIV3.ResponseObject} */
+    const responseObject = api.paths['/description'].get.responses['200']
+    t.ok(responseObject)
+    t.equal(responseObject.description, description)
+
+    const schemaObject = responseObject.content['application/json'].schema
+    t.ok(schemaObject)
+    t.equal(schemaObject.description, description)
+  })
+
+  test('description alongside responseDescription only describes response body', async t => {
+    // Given a /responseDescription endpoint that also has a |responseDescription| field in its response schema
+    const fastify = Fastify()
+    fastify.register(fastifySwagger, openapiOption)
+    fastify.get('/responseDescription', {
+      schema: {
+        response: {
+          200: {
+            responseDescription,
+            description,
+            type: 'string'
+          }
+        }
+      }
+    }, () => {})
+    await fastify.ready()
+
+    // When the Swagger schema is generated
+    const swaggerObject = fastify.swagger()
+    const api = await Swagger.validate(swaggerObject)
+
+    // Then the /responseDescription endpoint uses the |responseDescription| only for the Response Object and the |description| only for the Schema Object
+    const responseObject = api.paths['/responseDescription'].get.responses['200']
+    t.ok(responseObject)
+    t.equal(responseObject.description, responseDescription)
+
+    const schemaObject = responseObject.content['application/json'].schema
+    t.ok(schemaObject)
+    t.equal(schemaObject.description, description)
+    t.equal(schemaObject.responseDescription, undefined)
+  })
+})

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -229,11 +229,11 @@ test('support response headers', async t => {
   t.notOk(definedPath.responses['200'].schema.headers)
 })
 
-test('response: description and responseDescription', async () => {
+test('response: description and x-response-description', async () => {
   const description = 'description - always that of response body, sometimes also that of response as a whole'
   const responseDescription = 'description only for the response as a whole'
 
-  test('description without responseDescription doubles as responseDescription', async t => {
+  test('description without x-response-description doubles as response description', async t => {
     // Given a /description endpoint with only a |description| field in its response schema
     const fastify = Fastify()
     fastify.register(fastifySwagger, {
@@ -263,8 +263,8 @@ test('response: description and responseDescription', async () => {
     t.equal(responseObject.schema.description, description)
   })
 
-  test('description alongside responseDescription only describes response body', async t => {
-    // Given a /responseDescription endpoint that also has a |responseDescription| field in its response schema
+  test('description alongside x-response-description only describes response body', async t => {
+    // Given a /responseDescription endpoint that also has a |'x-response-description'| field in its response schema
     const fastify = Fastify()
     fastify.register(fastifySwagger, {
       routePrefix: '/docs',
@@ -274,7 +274,7 @@ test('response: description and responseDescription', async () => {
       schema: {
         response: {
           200: {
-            responseDescription,
+            'x-response-description': responseDescription,
             description,
             type: 'string'
           }

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -228,3 +228,38 @@ test('support response headers', async t => {
   t.same(definedPath.responses['200'].headers, opt.schema.response['200'].headers)
   t.notOk(definedPath.responses['200'].schema.headers)
 })
+
+test('response: description and responseDescription', async () => {
+  const description = 'description - always that of response body, sometimes also that of response as a whole'
+  // const responseDescription = 'description only for the response as a whole'
+
+  test('description without responseDescription doubles as responseDescription', async t => {
+    // Given a /description endpoint with only a |description| field in its response schema
+    const fastify = Fastify()
+    fastify.register(fastifySwagger, {
+      routePrefix: '/docs',
+      exposeRoute: true
+    })
+    fastify.get('/description', {
+      schema: {
+        response: {
+          200: {
+            description,
+            type: 'string'
+          }
+        }
+      }
+    }, () => {})
+    await fastify.ready()
+
+    // When the Swagger schema is generated
+    const swaggerObject = fastify.swagger()
+    const api = await Swagger.validate(swaggerObject)
+
+    // Then the /description endpoint uses the |description| as both the description of the Response Object as well as of its Schema Object
+    const responseObject = api.paths['/description'].get.responses['200']
+    t.ok(responseObject)
+    t.equal(responseObject.description, description)
+    t.equal(responseObject.schema.description, description)
+  })
+})


### PR DESCRIPTION
## Before
Any description provided in a response schema was also used for the response itself.

For example, this route:

```js
fastify.get('/description', {
  schema: {
    response: {
      200: {
        description: 'response and schema description',
        type: 'string'
      }
    }
  }
}, () => {})
```

generated this schema:

```json
{
  "/description": {
    "get": {
      "responses": {
        "200": {
          "description": "response and schema description",
          "schema": {
            "description": "response and schema description",
            "type": "string"
          }
        }
      }
    }
  }
}
```

## Now
The existing behavior stands, but you can also provide an independent description of the response via the `responseDescription` field.

For example, this route:

```js
    fastify.get('/responseDescription', {
      schema: {
        response: {
          200: {
            responseDescription: 'description for the response as a whole',
            description: 'description for the response body',
            type: 'string'
          }
        }
      }
    }, () => {})
```

generates this schema:

```json
{
  "/responseDescription": {
    "get": {
      "responses": {
        "200": {
          "description": "response description",
          "schema": {
            "description": "schema description",
            "type": "string"
          }
        }
      }
    }
  }
}
```

Finishes #336.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] run `npm run test` and `npm run benchmark` (NOTE: this project has no `benchmark` package script)
- [X] tests and/or benchmarks are included
- [X] updates applied to Swagger schema generation
- [x] updates applied to OpenAPI schema generation
- [X] documentation is changed or added
