### PR TITLE
fix(deps): Correctly add openapi-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "fs-extra": "^9.0.0",
     "joi": "^14.3.1",
     "joi-to-json-schema": "^5.1.0",
-    "openapi-types": "^7.0.1",
     "pre-commit": "^1.2.2",
     "standard": "^16.0.1",
     "swagger-parser": "^10.0.2",
@@ -49,7 +48,8 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^3.3.0",
     "js-yaml": "^4.0.0",
-    "json-schema-resolver": "^1.2.0"
+    "json-schema-resolver": "^1.2.0",
+    "openapi-types": "^7.0.1"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
This moves `openapi-types` to dependencies so that the typescript types in `index.d.ts` work correctly.

Fixes #340 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
