### PR TITLE
Fix swagger nxx response

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ fastify.ready(err => {
  | openapi       | {}       | Openapi configuration.                |
  | transform     | null     | Transform method for schema.          |
 
+##### 2XX status code
+`fastify` itself support the `2xx`, `3xx` status, however `swagger` itself do not support this featuer. We will help you to transform the `2xx` status code into `200` and we will omit `2xx` status code when you already declared `200` status code.
+Note: `openapi` will not be affected as it support the `2xx` syntax.
+
+Example:
+```js
+{
+  response: {
+    '2xx': {
+      description: '2xx'
+      type: 'object'
+    }
+  }
+}
+
+// it will becomes below
+{
+  response: {
+    200: {
+      schema: {
+        description: '2xx'
+        type: 'object'
+      }
+    }
+  }
+}
+```
+
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
   ```js

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -163,11 +163,14 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
 
   const responsesContainer = {}
 
-  Object.keys(fastifyResponseJson).forEach(key => {
-    // 2xx is not supported by swagger
+  const statusCodes = Object.keys(fastifyResponseJson)
 
-    const rawJsonSchema = fastifyResponseJson[key]
+  statusCodes.forEach(statusCode => {
+    const rawJsonSchema = fastifyResponseJson[statusCode]
     const resolved = transformDefsToComponents(ref.resolve(rawJsonSchema))
+
+    // 2xx require to be all upper-case
+    statusCode = statusCode.toUpperCase()
 
     const content = {}
 
@@ -181,7 +184,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
       }
     })
 
-    responsesContainer[key] = {
+    responsesContainer[statusCode] = {
       content,
       description: rawJsonSchema.description || 'Default Response'
     }

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -179,13 +179,21 @@ function resolveResponse (fastifyResponseJson, ref) {
 
   const responsesContainer = {}
 
-  Object.keys(fastifyResponseJson).forEach(key => {
-    // 2xx is not supported by swagger
+  const statusCodes = Object.keys(fastifyResponseJson)
 
-    const rawJsonSchema = fastifyResponseJson[key]
+  statusCodes.forEach(statusCode => {
+    const rawJsonSchema = fastifyResponseJson[statusCode]
     const resolved = ref.resolve(rawJsonSchema)
 
-    responsesContainer[key] = {
+    // 2xx is not supported by swagger
+    const deXXStatusCode = statusCode.toUpperCase().replace('XX', '00')
+    // conflict when we have both 2xx and 200
+    if (statusCode.toUpperCase().includes('XX') && statusCodes.includes(deXXStatusCode)) {
+      return
+    }
+    statusCode = deXXStatusCode
+
+    responsesContainer[statusCode] = {
       schema: resolved,
       description: rawJsonSchema.description || 'Default Response'
     }

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -40,3 +40,35 @@ test('suport - oneOf, anyOf, allOf', t => {
       })
   })
 })
+
+test('support 2xx response', async t => {
+  const opt = {
+    schema: {
+      response: {
+        '2XX': {
+          type: 'object'
+        },
+        '3xx': {
+          type: 'object'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    openapi: true,
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['2XX'].description, 'Default Response')
+  t.same(definedPath.responses['3XX'].description, 'Default Response')
+})

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -100,3 +100,64 @@ test('response default description', async t => {
   const definedPath = api.paths['/'].get
   t.same(definedPath.responses['200'].description, 'Default Response')
 })
+
+test('response 2xx', async t => {
+  const opt = {
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['200'].description, 'Default Response')
+  t.notOk(definedPath.responses['2xx'])
+})
+
+test('response conflict 2xx and 200', async t => {
+  const opt = {
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          description: '2xx'
+        },
+        200: {
+          type: 'object',
+          description: '200'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['200'].description, '200')
+  t.notOk(definedPath.responses['2xx'])
+})

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -126,7 +126,7 @@ test('response 2xx', async t => {
 
   const definedPath = api.paths['/'].get
   t.same(definedPath.responses['200'].description, 'Default Response')
-  t.notOk(definedPath.responses['2xx'])
+  t.notOk(definedPath.responses['2XX'])
 })
 
 test('response conflict 2xx and 200', async t => {
@@ -159,5 +159,5 @@ test('response conflict 2xx and 200', async t => {
 
   const definedPath = api.paths['/'].get
   t.same(definedPath.responses['200'].description, '200')
-  t.notOk(definedPath.responses['2xx'])
+  t.notOk(definedPath.responses['2XX'])
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Resolve: #250

Caption from [swagger](https://swagger.io/docs/specification/describing-responses/)
`
To define a range of response codes, you may use the following range definitions: 1XX, 2XX, 3XX, 4XX, and 5XX. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.
`

I do not introduce a new option as @Eomm suggestion. It will also not throwing error because it may break someone code.

Behavior for Swagger 
- When I see `Nxx` status code, transform it to `200` status code.
- If we find conflict of `200` status code, drop the transformed one as it is more general response.
- Append the transformed status code to response.

Behavior for OpenAPI
- All `Nxx` status code will enforce upper case.
- Append the transformed status code to response.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
