### PR TITLE
feat: response headers and empty body

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ Example:
 }
 ```
 
+##### response headers
+You can decorate your own response headers by follow the below example.
+```js
+{
+  response: {
+    200: {
+      type: 'object',
+      headers: {
+        'X-Foo': {
+          type: 'string'
+        }
+      }
+    }
+  }
+}
+```
+Note: You need to specify `type` property when you decorate the response headers, otherwise the schema will be modify by `fastify`.
+
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
   ```js

--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ You can decorate your own response headers by follow the below example.
 ```
 Note: You need to specify `type` property when you decorate the response headers, otherwise the schema will be modify by `fastify`.
 
+##### status code 204
+We support status code 204 and return empty body. Please specify `type: 'null'` for the response otherwise `fastify` itself will fail to compile the schema.
+```js
+{
+  response: {
+    204: {
+      type: 'null',
+      description: 'No Content'
+    }
+  }
+}
+```
+
 ##### static
  `static` mode should be configured explicitly. In this mode `fastify-swagger` serves given specification, you should craft it yourself.
   ```js

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -172,22 +172,47 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
     // 2xx require to be all upper-case
     statusCode = statusCode.toUpperCase()
 
-    const content = {}
-
-    if ((Array.isArray(produces) && produces.length === 0) || typeof produces === 'undefined') {
-      produces = ['application/json']
-    }
-
-    produces.forEach((produce) => {
-      content[produce] = {
-        schema: resolved
-      }
-    })
-
-    responsesContainer[statusCode] = {
-      content,
+    const response = {
       description: rawJsonSchema.description || 'Default Response'
     }
+
+    // add headers when there are any.
+    if (rawJsonSchema.headers) {
+      response.headers = {}
+      Object.keys(rawJsonSchema.headers).forEach(function (key) {
+        const header = {
+          schema: rawJsonSchema.headers[key]
+        }
+
+        if (rawJsonSchema.headers[key].description) {
+          header.description = rawJsonSchema.headers[key].description
+          // remove invalid field
+          delete header.schema.description
+        }
+
+        response.headers[key] = header
+      })
+      // remove invalid field
+      delete resolved.headers
+    }
+
+    if (statusCode.toString() !== '204') {
+      const content = {}
+
+      if ((Array.isArray(produces) && produces.length === 0) || typeof produces === 'undefined') {
+        produces = ['application/json']
+      }
+
+      produces.forEach((produce) => {
+        content[produce] = {
+          schema: resolved
+        }
+      })
+
+      response.content = content
+    }
+
+    responsesContainer[statusCode] = response
   })
 
   return responsesContainer

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -193,10 +193,23 @@ function resolveResponse (fastifyResponseJson, ref) {
     }
     statusCode = deXXStatusCode
 
-    responsesContainer[statusCode] = {
-      schema: resolved,
+    const response = {
       description: rawJsonSchema.description || 'Default Response'
     }
+
+    // add headers when there are any.
+    if (rawJsonSchema.headers) {
+      response.headers = rawJsonSchema.headers
+      // remove invalid field
+      delete resolved.headers
+    }
+
+    // add schema when status code is not 204
+    if (statusCode.toString() !== '204') {
+      response.schema = resolved
+    }
+
+    responsesContainer[statusCode] = response
   })
 
   return responsesContainer


### PR DESCRIPTION
This PR used to fix the existing bug of handling empty body and add the function for setting response header.
Resolve: #313
Resolve: #335

It is a little bit bulky in `openapi` implementation, as we need to transform most of the schema.

Header Behavior for Swagger:
- add `headers` in response
- remove `headers` from schema 

Header Behavior for OpenAPI:
- add `headers` in response which need to do some `transformation`
- remove `headers` from schema

Note: we must use the keyword `delete` in here because `swagger.validate` itself will validate invalid field even you set it as `undefined`.

Empty Body Behavior:
- we only add `schema` into `response` when status code is not equal to 204

Note: we need to cast status code to `string` to ensure the check pass.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
