### PR TITLE
feat: pass swagger-ui additional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ fastify.register(require('fastify-swagger'), {
       }
     }
   },
+  uiConfig: {
+    docExpansion: 'full',
+    deepLinking: false
+  },
   exposeRoute: true
 })
 
@@ -167,14 +171,17 @@ fastify.ready(err => {
 
 ##### options
 
- | option        | default  | description                           |
- |---------------|----------|---------------------------------------|
- | exposeRoute   | false    | Exposes documentation route.          |
- | hiddenTag     | X-HIDDEN | Tag to control hiding of routes.      |
- | stripBasePath | true     | Strips base path from routes in docs. |
- | swagger       | {}       | Swagger configuration.                |
- | openapi       | {}       | Openapi configuration.                |
- | transform     | null     | Transform method for schema.          |
+ | option        | default  | description                                                                                                               |
+ | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+ | exposeRoute   | false    | Exposes documentation route.                                                                                              |
+ | hiddenTag     | X-HIDDEN | Tag to control hiding of routes.                                                                                          |
+ | stripBasePath | true     | Strips base path from routes in docs.                                                                                     |
+ | swagger       | {}       | Swagger configuration.                                                                                                    |
+ | openapi       | {}       | Openapi configuration.                                                                                                    |
+ | transform     | null     | Transform method for schema.                                                                                              |
+ | uiConfig*     | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
+
+> `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
 
 ##### 2XX status code
 `fastify` itself support the `2xx`, `3xx` status, however `swagger` itself do not support this featuer. We will help you to transform the `2xx` status code into `200` and we will omit `2xx` status code when you already declared `200` status code.
@@ -226,17 +233,20 @@ Example:
   By default, this is the directory where the main spec file is located. Provided value should be an absolute path **without** trailing slash.
 <a name="additional"></a>
 #### additional
+
 If you pass `{ exposeRoute: true }` during the registration the plugin will expose the documentation with the following apis:
 
-|  url  |  description   |
-|-------|----------------|
-|`'/documentation/json'` | the json object representing the api  |
-|`'/documentation/yaml'` | the yaml object representing the api  |
-|`'/documentation/'` | the swagger ui  |
-|`'/documentation/*'`| external files which you may use in `$ref`|
+| url                     | description                                |
+| ----------------------- | ------------------------------------------ |
+| `'/documentation/json'` | the json object representing the api       |
+| `'/documentation/yaml'` | the yaml object representing the api       |
+| `'/documentation/'`     | the swagger ui                             |
+| `'/documentation/*'`    | external files which you may use in `$ref` |
 
 ##### Overwrite swagger url end-point
+
 If you would like to overwrite the `/documentation` url you can use the `routePrefix` option.
+
 ```js
 fastify.register(require('fastify-swagger'), {
   swagger: {
@@ -254,7 +264,9 @@ fastify.register(require('fastify-swagger'), {
 ```
 
 ##### Convert routes schema
+
 If you would like to use different schemas like, let's say [Joi](https://github.com/hapijs/joi), you can pass a synchronous `transform` method in the options to convert them back to standard JSON schemas expected by this plugin to generate the documentation (`dynamic` mode only).
+
 ```js
 const convert = require('joi-to-json-schema')
 
@@ -280,7 +292,9 @@ fastify.register(require('fastify-swagger'), {
 ```
 
 <a name="swagger.options"></a>
+
 ### swagger options
+
 Calling `fastify.swagger` will return to you a JSON object representing your api, if you pass `{ yaml: true }` to `fastify.swagger`, it will return you a yaml string.
 
 ### Open API (OA) Parameter Options

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -16,7 +16,8 @@ module.exports = function (fastify, opts, done) {
 
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'
-    fastify.register(require('../routes'), { prefix })
+    const uiConfig = opts.uiConfig || {}
+    fastify.register(require('../routes'), { prefix, uiConfig })
   }
 
   const cache = {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -30,6 +30,15 @@ function fastifySwagger (fastify, opts, done) {
   })
 
   fastify.route({
+    url: '/uiConfig',
+    method: 'GET',
+    schema: { hide: true },
+    handler: (req, reply) => {
+      reply.send(opts.uiConfig)
+    }
+  })
+
+  fastify.route({
     url: '/json',
     method: 'GET',
     schema: { hide: true },

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -24,7 +24,8 @@ filesToCopy.forEach(filename => {
 })
 
 const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
-  .replace(/window.onload = function\(\) {\n/, `
+  .replace(/<script>((.| |\n)*)<\/script>/, `
+  <script>
   window.onload = function () {
     function resolveUrl (url) {
         const anchor = document.createElement('a')
@@ -56,17 +57,18 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
           return cb(resConfig);
         })
      }
-  `)
-  .replace(/window.ui = ui/, '')
-  .replace(
-    /const ui = SwaggerUIBundle\({((.|\n)*)}\)\n(.*)(\/\/ End)/,
-    `const buildUi = function (config) {
+
+    // Begin Swagger UI call region
+    const buildUi = function (config) {
       const ui = SwaggerUIBundle(config)
       window.ui = ui
     }
+    // End Swagger UI call region
+
     resolveConfig(buildUi);
-    // End`
-  )
+  }
+  </script>
+  `)
 
 fse.writeFileSync(resolve('./static/index.html'), newIndex)
 

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -33,7 +33,7 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
     }
 
     function resolveConfig (cb) {
-      return fetch('./uiConfig')
+      return fetch('/uiConfig')
         .then(res => res.json())
         .then((config) => {
           return cb({

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -33,7 +33,7 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
     }
 
     function resolveConfig (cb) {
-      return fetch('../uiConfig')
+      return fetch(resolveUrl('./uiConfig'))
         .then(res => res.json())
         .then((config) => {
           return cb({

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -38,11 +38,22 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
       )
         .then(res => res.json())
         .then((config) => {
-          return cb({
-            ...config,
+          const resConfig = Object.assign({}, {
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIStandalonePreset
+            ],
+            plugins: [
+              SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout"
+          }, config, {
             url: resolveUrl('./json').replace('static/json', 'json'),
             oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html')
-          })
+          });
+          return cb(resConfig);
         })
      }
   `)

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -33,7 +33,9 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
     }
 
     function resolveConfig (cb) {
-      return fetch(resolveUrl('./uiConfig'))
+      return fetch(
+        resolveUrl('./uiConfig').replace('static/uiConfig', 'uiConfig')
+      )
         .then(res => res.json())
         .then((config) => {
           return cb({

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -33,7 +33,7 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
     }
 
     function resolveConfig (cb) {
-      return fetch('/uiConfig')
+      return fetch('../uiConfig')
         .then(res => res.json())
         .then((config) => {
           return cb({

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -24,17 +24,35 @@ filesToCopy.forEach(filename => {
 })
 
 const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
-  .replace('window.ui = ui', `window.ui = ui
+  .replace(/window.onload = function\(\) {\n/, `
+  window.onload = function () {
+    function resolveUrl (url) {
+        const anchor = document.createElement('a')
+        anchor.href = url
+        return anchor.href
+    }
 
-  function resolveUrl (url) {
-      const anchor = document.createElement('a')
-      anchor.href = url
-      return anchor.href
-  }`)
+    function resolveConfig (cb) {
+      return fetch('./uiConfig')
+        .then(res => res.json())
+        .then((config) => {
+          return cb({
+            ...config,
+            url: resolveUrl('./json').replace('static/json', 'json'),
+            oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html')
+          })
+        })
+     }
+  `)
+  .replace(/window.ui = ui/, '')
   .replace(
-    /url: "(.*)",/,
-    `url: resolveUrl('./json').replace('static/json', 'json'),
-    oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html'),`
+    /const ui = SwaggerUIBundle\({((.|\n)*)}\)\n(.*)(\/\/ End)/,
+    `const buildUi = function (config) {
+      const ui = SwaggerUIBundle(config)
+      window.ui = ui
+    }
+    resolveConfig(buildUi);
+    // End`
   )
 
 fse.writeFileSync(resolve('./static/index.html'), newIndex)

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "prepare": "node lib/util/prepare-swagger-ui",
     "prepublishOnly": "npm run prepare",
-    "test": "standard && tap --100 test/*.js test/**/*.js test/**/**/*.js && npm run typescript",
-    "test:ci": "standard && tap test/*.js test/**/*.js test/**/**/*.js --coverage-report=lcovonly && npm run typescript",
+    "test": "standard && tap --100 'test/**/*.js' && npm run typescript",
+    "test:ci": "standard && tap 'test/**/*.js' --coverage-report=lcovonly && npm run typescript",
     "typescript": "tsd"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "prepare": "node lib/util/prepare-swagger-ui",
     "prepublishOnly": "npm run prepare",
-    "test": "standard && tap --100 test/**/*.js && npm run typescript",
-    "test:ci": "standard && tap test/**/*.js --coverage-report=lcovonly && npm run typescript",
+    "test": "standard && tap --100 test/*.js test/**/*.js test/**/**/*.js && npm run typescript",
+    "test:ci": "standard && tap test/*.js test/**/*.js test/**/**/*.js --coverage-report=lcovonly && npm run typescript",
     "typescript": "tsd"
   },
   "repository": {
@@ -41,7 +41,7 @@
     "standard": "^16.0.1",
     "swagger-parser": "^10.0.2",
     "swagger-ui-dist": "3.41.1",
-    "tap": "^14.10.8",
+    "tap": "^14.11.0",
     "tsd": "^0.14.0"
   },
   "dependencies": {

--- a/test/route.js
+++ b/test/route.js
@@ -115,7 +115,7 @@ test('/documentation/uiConfig route', t => {
     t.error(err)
 
     const payload = JSON.parse(res.payload)
-    
+
     t.match(payload, uiConfig, 'Invalid uiConfig received')
   })
 })

--- a/test/route.js
+++ b/test/route.js
@@ -116,7 +116,7 @@ test('/documentation/uiConfig route', t => {
 
     const payload = JSON.parse(res.payload)
 
-    t.match(payload, uiConfig, 'Invalid uiConfig received')
+    t.match(payload, uiConfig, 'uiConfig should be valid')
   })
 })
 

--- a/test/route.js
+++ b/test/route.js
@@ -86,6 +86,40 @@ test('/documentation/json route', t => {
   })
 })
 
+test('/documentation/uiConfig route', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  const uiConfig = {
+    docExpansion: 'full'
+  }
+
+  const opts = {
+    ...swaggerOption,
+    uiConfig
+  }
+
+  fastify.register(fastifySwagger, opts)
+
+  fastify.get('/', () => {})
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/uiConfig'
+  }, (err, res) => {
+    t.error(err)
+
+    const payload = JSON.parse(res.payload)
+    
+    t.match(payload, uiConfig, 'Invalid uiConfig received')
+  })
+})
+
 test('fastify.swagger should return a valid swagger yaml', t => {
   t.plan(4)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
## Porpouse

This PR allows to pass a dynamic configuration to the generated swagger UI. The option that should be used in the plugin configuration in order to accomplish that is `uiConfig`.

Configuration docs: https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md

## Implementation

Since there is an issue configuring `swagger-ui-dist` (that distributes only static files, see https://github.com/swagger-api/swagger-ui/issues/5710) without changing the content of the static assets, the only way to configure the UI with a dynamic external configuration is by editing the `index.html` file and the script within that loads the swagger ui in the page.

There were two approaches:
1. Intercepting the `index.html` request on the documentation routes and distributing an altered html file that load swagger UI with the configuration merged with the one passed by the user.
2. Editing the file `index.html` when the project gets prepared (`npm run prepare`) in order to retrieving a remote configuration fetched through an XHR request on a designated endpoint.

Since the index.html file was already edited in the prepare stage I went for the second approach. Now a new route under `GET documentation/uiConfig` gets declared and returns the final ui configuration and the script inside the index page fetches the configuration from that endpoint. Finally the page loads the swagger ui from the given configuration.

## Drawbacks

Since there is no way to serialize functions over HTTP and JSON there is no way to pass functions to the parameters of the `uiConfig`, so only string/object/number configuration keys will be effective. Neither the first alternative implementation allowed to do that (at least without writing the plain function in the HTML file). However I think this is a fair compromise.

## Related issues

- #228 
- [swagger-ui#5710](https://github.com/swagger-api/swagger-ui/issues/5710)

## Others

The `npm run test` didn't run all the test inside the folder `test/` since the regex in the command was working only at the first directory level. Now it runs all the test till the 3rd directory level.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
