### PR TITLE
Default pkg to empty object in case readPackageJson fails

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -35,8 +35,8 @@ function prepareDefaultOptions (opts) {
   }
 }
 
-function prepareOpenapiObject (opts, done) {
-  const pkg = readPackageJson(done)
+function prepareOpenapiObject (opts) {
+  const pkg = readPackageJson()
   const openapiObject = {
     openapi: '3.0.3',
     info: {

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -46,7 +46,7 @@ function prepareDefaultOptions (opts) {
 }
 
 function prepareSwaggerObject (opts, done) {
-  const pkg = readPackageJson(done)
+  const pkg = readPackageJson(done) || {}
   const swaggerObject = {
     swagger: '2.0',
     info: {

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -45,8 +45,8 @@ function prepareDefaultOptions (opts) {
   }
 }
 
-function prepareSwaggerObject (opts, done) {
-  const pkg = readPackageJson(done) || {}
+function prepareSwaggerObject (opts) {
+  const pkg = readPackageJson()
   const swaggerObject = {
     swagger: '2.0',
     info: {

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -92,11 +92,11 @@ function resolveLocalRef (jsonSchema, externalSchemas) {
   return resolveLocalRef(externalSchemas[localRef], externalSchemas)
 }
 
-function readPackageJson (done) {
+function readPackageJson () {
   try {
     return JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json')))
   } catch (err) {
-    return done(err)
+    return {}
   }
 }
 


### PR DESCRIPTION
This change addresses a regression when bundling with webpack after upgrading from v3 to v4 of this plugin.
The plugin fails after bundling because the `package.json` of this library is not present in the expected relative location and an attempt is made to read from an `undefined` object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
