### PR TITLE
fix: static ui config is missing

### DIFF
--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -61,6 +61,7 @@ module.exports = function (fastify, opts, done) {
   if (opts.exposeRoute === true) {
     const options = {
       prefix: opts.routePrefix || '/documentation',
+      uiConfig: opts.uiConfig || {},
       baseDir: opts.specification.baseDir
     }
 

--- a/test/mode/static.js
+++ b/test/mode/static.js
@@ -752,3 +752,54 @@ test('inserts default opts in fastifySwaggerDynamic (dynamic.js)', t => {
     t.pass('Inserted default option for fastifySwagger.')
   })
 })
+
+test('/documentation/uiConfig should have default', t => {
+  const config = {
+    exposeRoute: true,
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml',
+      baseDir: resolve(__dirname, '..', '..', 'static')
+    }
+  }
+
+  t.plan(3)
+  const fastify = new Fastify()
+  fastify.register(fastifySwagger, config)
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/uiConfig'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, '{}')
+  })
+})
+
+test('/documentation/uiConfig can be customize', t => {
+  const config = {
+    exposeRoute: true,
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml',
+      baseDir: resolve(__dirname, '..', '..', 'static')
+    },
+    uiConfig: {
+      docExpansion: 'full'
+    }
+  }
+
+  t.plan(3)
+  const fastify = new Fastify()
+  fastify.register(fastifySwagger, config)
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/uiConfig'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, '{"docExpansion":"full"}')
+  })
+})


### PR DESCRIPTION
Closes #353 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
