### PR TITLE
fix: openapi parameters description

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -96,22 +96,28 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
     case 'cookie':
     case 'query':
       toOpenapiProp = function (propertyName, jsonSchemaElement) {
-        return {
+        const result = {
           in: container,
           name: propertyName,
           required: jsonSchemaElement.required,
           schema: jsonSchemaElement
         }
+        // description should be optional
+        if (jsonSchemaElement.description) result.description = jsonSchemaElement.description
+        return result
       }
       break
     case 'path':
       toOpenapiProp = function (propertyName, jsonSchemaElement) {
-        return {
+        const result = {
           in: container,
           name: propertyName,
           required: true,
           schema: jsonSchemaElement
         }
+        // description should be optional
+        if (jsonSchemaElement.description) result.description = jsonSchemaElement.description
+        return result
       }
       break
     case 'header':
@@ -131,8 +137,10 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
 
   return Object.keys(obj).map((propKey) => {
     const jsonSchema = toOpenapiProp(propKey, obj[propKey])
-    // it is needed as required in schema is invalid prop
-    delete jsonSchema.schema.required
+    // it is needed as required in schema is invalid prop - delete only if needed
+    if (typeof jsonSchema.schema.required !== 'undefined') delete jsonSchema.schema.required
+    // it is needed as description in schema is invalid prop - delete only if needed
+    if (typeof jsonSchema.schema.description !== 'undefined') delete jsonSchema.schema.description
     return jsonSchema
   })
 }

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -415,7 +415,6 @@ test('cookie, query, path description', t => {
         ])
       })
       .catch(function (err) {
-        console.log(err)
         t.fail(err)
       })
   })

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -9,7 +9,7 @@ const {
   schemaAllOf
 } = require('../../../examples/options')
 
-test('suport - oneOf, anyOf, allOf', t => {
+test('support - oneOf, anyOf, allOf', t => {
   t.plan(3)
   const fastify = Fastify()
 


### PR DESCRIPTION
Changes
- parameters trigger `delete` only if it is needed
- fix description is missing for `path`, `cookies` and `query`
- fix test case typo

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
