### PR TITLE
fix: multiple path params cannot be recognize within two brackets

### DIFF
--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -54,16 +54,14 @@ function shouldRouteHide (schema, hiddenTag) {
 // This function converts the url in a swagger compliant url string
 // => '/user/{id}'
 function formatParamUrl (url) {
-  let start = url.indexOf('/:')
-  if (start === -1) return url
-
-  const end = url.indexOf('/', ++start)
-
-  if (end === -1) {
-    return url.slice(0, start) + '{' + url.slice(++start) + '}'
-  } else {
-    return formatParamUrl(url.slice(0, start) + '{' + url.slice(++start, end) + '}' + url.slice(end))
+  const regex = /:([a-zA-Z0-9]+)/g
+  let found = regex.exec(url)
+  while (found !== null) {
+    const [full, param] = found
+    url = url.replace(full, '{' + param + '}')
+    found = regex.exec(url)
   }
+  return url
 }
 
 function resolveLocalRef (jsonSchema, externalSchemas) {

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { test } = require('tap')
+const { formatParamUrl } = require('../lib/util/common')
+
+test('formatParamUrl', t => {
+  t.plan(3)
+
+  t.test('support /example/:userId', t => {
+    t.plan(1)
+    const url = formatParamUrl('/example/:userId')
+    t.strictEqual(url, '/example/{userId}')
+  })
+
+  t.test('support /example/:userId/:secretToken', t => {
+    t.plan(1)
+    const url = formatParamUrl('/example/:userId/:secretToken')
+    t.strictEqual(url, '/example/{userId}/{secretToken}')
+  })
+
+  t.test('support /example/near/:lat-:lng/radius/:r', t => {
+    t.plan(1)
+    const url = formatParamUrl('/example/near/:lat-:lng/radius/:r')
+    t.strictEqual(url, '/example/near/{lat}-{lng}/radius/{r}')
+  })
+})


### PR DESCRIPTION
neither OpenAPI nor Swagger support `RegExp` in path, so we cannot support all the path like `fastify` does.
More Info: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#path-templating

Changes:
- add support for url like `/example/near/:lat-:lng/radius/:r`

Close: #100 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
