### PR TITLE
feat: pass swagger-ui initOAuth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ fastify.ready(err => {
  | openapi       | {}       | OpenAPI configuration.                                                                                                    |
  | transform     | null     | Transform method for schema.                                                                                              |
  | uiConfig*     | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
+ | initOAuth     | {}       | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)
 
 > `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,17 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
    * Overwrite the route schema
    */
   transform?: Function;
+  initOAuth?: Partial<{
+    clientId: string,
+    clientSecret: string,
+    realm: string,
+    appName: string,
+    scopeSeparator: string,
+    scopes: string | string[],
+    additionalQueryStringParams: { [key: string]: any },
+    useBasicAuthenticationWithAccessCodeGrant: boolean,
+    usePkceWithAuthorizationCodeGrant: boolean
+  }>
 }
 
 export interface StaticPathSpec {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -17,7 +17,8 @@ module.exports = function (fastify, opts, done) {
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'
     const uiConfig = opts.uiConfig || {}
-    fastify.register(require('../routes'), { prefix, uiConfig })
+    const initOAuth = opts.initOAuth || {}
+    fastify.register(require('../routes'), { prefix, uiConfig, initOAuth })
   }
 
   const cache = {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -39,6 +39,15 @@ function fastifySwagger (fastify, opts, done) {
   })
 
   fastify.route({
+    url: '/initOAuth',
+    method: 'GET',
+    schema: { hide: true },
+    handler: (req, reply) => {
+      reply.send(opts.initOAuth)
+    }
+  })
+
+  fastify.route({
     url: '/json',
     method: 'GET',
     schema: { hide: true },

--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -62,6 +62,13 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
     const buildUi = function (config) {
       const ui = SwaggerUIBundle(config)
       window.ui = ui
+
+      fetch(resolveUrl('./initOAuth').replace('static/initOAuth', 'initOAuth'))
+        .then(res => res.json())
+        .then((config) => {
+          ui.initOAuth(config);
+      });
+      
     }
     // End Swagger UI call region
 

--- a/test/route.js
+++ b/test/route.js
@@ -120,6 +120,40 @@ test('/documentation/uiConfig route', t => {
   })
 })
 
+test('/documentation/initOAuth route', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  const initOAuth = {
+    scopes: ['openid', 'profile', 'email', 'offline_access']
+  }
+
+  const opts = {
+    ...swaggerOption,
+    initOAuth
+  }
+
+  fastify.register(fastifySwagger, opts)
+
+  fastify.get('/', () => {})
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/initOAuth'
+  }, (err, res) => {
+    t.error(err)
+
+    const payload = JSON.parse(res.payload)
+
+    t.match(payload, initOAuth, 'initOAuth should be valid')
+  })
+})
+
 test('fastify.swagger should return a valid swagger yaml', t => {
   t.plan(4)
   const fastify = Fastify()

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -112,6 +112,9 @@ app
         },
       },
     },
+    initOAuth: {
+      scopes: ['openid', 'profile', 'email', 'offline_access'],
+    },
   })
   .ready((err) => {
     app.swagger();


### PR DESCRIPTION
Following the approach of https://github.com/fastify/fastify-swagger/pull/351, this PR aims to make the Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/) configurable in a dynamic way. 

