### PR TITLE
fix: uiConfig types and initOAuth in static mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,40 @@ export interface FastifySwaggerOptions {
    * @default false
    */
   exposeRoute?: boolean;
+  /**
+   * Swagger UI Config
+   */
+  uiConfig?: Partial<{
+    deepLinking: boolean
+    displayOperationId: boolean
+    defaultModelsExpandDepth: number
+    defaultModelExpandDepth: number
+    defaultModelRendering: string
+    displayRequestDuration: boolean
+    docExpansion: string
+    filter: boolean | string
+    maxDisplayedTags: number
+    showExtensions: boolean
+    showCommonExtensions: boolean
+    useUnsafeMarkdown: boolean
+    syntaxHighlight: {
+      activate?: boolean
+      theme?: string
+    } | false
+    tryItOutEnabled: boolean
+  }>
+  
+  initOAuth?: Partial<{
+    clientId: string,
+    clientSecret: string,
+    realm: string,
+    appName: string,
+    scopeSeparator: string,
+    scopes: string | string[],
+    additionalQueryStringParams: { [key: string]: any },
+    useBasicAuthenticationWithAccessCodeGrant: boolean,
+    usePkceWithAuthorizationCodeGrant: boolean
+  }>
 }
 
 export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
@@ -60,17 +94,6 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
    * Overwrite the route schema
    */
   transform?: Function;
-  initOAuth?: Partial<{
-    clientId: string,
-    clientSecret: string,
-    realm: string,
-    appName: string,
-    scopeSeparator: string,
-    scopes: string | string[],
-    additionalQueryStringParams: { [key: string]: any },
-    useBasicAuthenticationWithAccessCodeGrant: boolean,
-    usePkceWithAuthorizationCodeGrant: boolean
-  }>
 }
 
 export interface StaticPathSpec {

--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -62,6 +62,7 @@ module.exports = function (fastify, opts, done) {
     const options = {
       prefix: opts.routePrefix || '/documentation',
       uiConfig: opts.uiConfig || {},
+      initOAuth: opts.initOAuth || {},
       baseDir: opts.specification.baseDir
     }
 

--- a/test/mode/static.js
+++ b/test/mode/static.js
@@ -805,6 +805,57 @@ test('/documentation/uiConfig can be customize', t => {
   })
 })
 
+test('/documentation/initOAuth should have default', t => {
+  const config = {
+    exposeRoute: true,
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml',
+      baseDir: resolve(__dirname, '..', '..', 'static')
+    }
+  }
+
+  t.plan(3)
+  const fastify = new Fastify()
+  fastify.register(fastifySwagger, config)
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/initOAuth'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, '{}')
+  })
+})
+
+test('/documentation/initOAuth can be customize', t => {
+  const config = {
+    exposeRoute: true,
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml',
+      baseDir: resolve(__dirname, '..', '..', 'static')
+    },
+    initOAuth: {
+      scopes: ['openid', 'profile', 'email', 'offline_access']
+    }
+  }
+
+  t.plan(3)
+  const fastify = new Fastify()
+  fastify.register(fastifySwagger, config)
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/initOAuth'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, '{"scopes":["openid","profile","email","offline_access"]}')
+  })
+})
+
 test('should still return valid swagger object when missing package.json', t => {
   const config = {
     mode: 'dynamic',

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -119,3 +119,14 @@ app
   .ready((err) => {
     app.swagger();
   });
+
+app.register(fastifySwagger, {
+  uiConfig: {
+    deepLinking: true,
+    defaultModelsExpandDepth: -1,
+    defaultModelExpandDepth: 1
+  }
+})
+.ready((err) => {
+  app.swagger();
+})


### PR DESCRIPTION
Changes:
- fix uiConfig typings is missing
- fix initOAuth cannot be customize in static mode

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
