### PR TITLE
ci: add `matrix.os` array to test on other os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,40 @@
 name: CI workflow
 on:
-    push:
-        paths-ignore:
-            - "*.md"
-    pull_request:
-        paths-ignore:
-            - "*.md"
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
     steps:
     - uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.1.5
       with:
         node-version: ${{ matrix.node-version }}
+
     - name: Install Dependencies
       run: npm install --ignore-scripts
+
     - name: Prepare
       run: npm run prepare
+
     - name: Test
       run: npm run test:ci
+
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master
       with:

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "prepare": "node lib/util/prepare-swagger-ui",
     "prepublishOnly": "npm run prepare",
-    "test": "standard && tap --100 'test/**/*.js' && npm run typescript",
-    "test:ci": "standard && tap 'test/**/*.js' --coverage-report=lcovonly && npm run typescript",
+    "test": "standard && tap --100 \"test/**/*.js\" && npm run typescript",
+    "test:ci": "standard && tap \"test/**/*.js\" --coverage-report=lcovonly && npm run typescript",
     "typescript": "tsd"
   },
   "repository": {


### PR DESCRIPTION
Had to swap out single quotes in test scripts with escaped double quotes, as Windows fails with single quotes.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
