### PR TITLE
Fixed crash when querystring/params/headers/cookies are references to global schemas

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -179,7 +179,11 @@ function resolveBodyParams (content, schema, consumes, ref) {
 }
 
 function resolveCommonParams (container, parameters, schema, ref, sharedSchemas) {
-  const resolved = transformDefsToComponents(ref.resolve(schema))
+  let resolved = transformDefsToComponents(ref.resolve(schema))
+  if (resolved.$ref && resolved.$ref.startsWith('#/components/schemas/')) {
+    const refParts = resolved.$ref.split('/')
+    resolved = ref.definitions().definitions[refParts[3]]
+  }
   const arr = plainJsonObjectToOpenapi3(container, resolved, sharedSchemas)
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -13,7 +13,17 @@ test('support $ref schema', t => {
   fastify.register(fastifySwagger, openapiOption)
   fastify.register(function (instance, _, done) {
     instance.addSchema({ $id: 'Order', type: 'object', properties: { id: { type: 'integer' } } })
-    instance.post('/', { schema: { body: { $ref: 'Order#' }, response: { 200: { $ref: 'Order#' } } } }, () => {})
+    instance.addSchema({ $id: 'Params', type: 'object', properties: { reqd: { type: 'string' } }, required: ['reqd'] })
+    instance.post('/', {
+      schema: {
+        body: { $ref: 'Order#' },
+        querystring: { $ref: 'Params#' },
+        params: { $ref: 'Params#' },
+        headers: { $ref: 'Params#' },
+        cookies: { $ref: 'Params#' },
+        response: { 200: { $ref: 'Order#' } }
+      }
+    }, () => {})
     done()
   })
 
@@ -23,7 +33,7 @@ test('support $ref schema', t => {
     const openapiObject = fastify.swagger()
     t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
+    Swagger.validate(JSON.parse(JSON.stringify(openapiObject)))
       .then(function (api) {
         t.pass('valid swagger object')
       })


### PR DESCRIPTION
Fixes #394

#### Checklist

- [X] run `npm run test` ~~and `npm run benchmark`~~
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Please let me know if there's a better way to access the global schemas. Also, I had to `JSON.parse(JSON.stringify(api))` the resulting API before calling `Swagger.validate()` in the test. I didn't figure out why yet.