### PR TITLE
fix error when using default=null

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -77,7 +77,7 @@ function normalizeUrl (url, servers, stripBasePath) {
 }
 
 function transformDefsToComponents (jsonSchema) {
-  if (typeof jsonSchema === 'object') {
+  if (typeof jsonSchema === 'object' && jsonSchema !== null) {
     Object.keys(jsonSchema).forEach(function (key) {
       if (key === '$ref') {
         jsonSchema[key] = jsonSchema[key].replace('definitions', 'components/schemas')

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -223,3 +223,33 @@ test('response: description and x-response-description', async () => {
     t.equal(schemaObject.responseDescription, undefined)
   })
 })
+
+test('support default=null', async t => {
+  const opt = {
+    schema: {
+      response: {
+        '2XX': {
+          type: 'string',
+          nullable: true,
+          default: null
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    openapi: true,
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['2XX'].default, null)
+})


### PR DESCRIPTION
When using `default: null` in a schema, and fastify-swagger is configured to output OpenAPI 3.0, this error will happen:
```
 FAIL  test/spec/openapi/schema.js
 ✖ Cannot convert undefined or null to object

  test: support default=null
  stack: |
    Function.keys (<anonymous>)
    transformDefsToComponents (lib/spec/openapi/utils.js:81:12)
    forEach (lib/spec/openapi/utils.js:85:27)
    Array.forEach (<anonymous>)
    transformDefsToComponents (lib/spec/openapi/utils.js:81:29)
    forEach (lib/spec/openapi/utils.js:200:22)
    Array.forEach (<anonymous>)
    resolveResponse (lib/spec/openapi/utils.js:198:15)
    prepareOpenapiMethod (lib/spec/openapi/utils.js:284:29)
    Object.swagger (lib/spec/openapi/index.js:45:29)
  type: TypeError
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
