### PR TITLE
feat: better csp integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,18 +173,18 @@ fastify.ready(err => {
 
 ##### options
 
- | option             | default  | description                                                                                                               |
- | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
- | exposeRoute        | false    | Exposes documentation route.                                                                                              |
- | hiddenTag          | X-HIDDEN | Tag to control hiding of routes.                                                                                          |
- | stripBasePath      | true     | Strips base path from routes in docs.                                                                                     |
- | swagger            | {}       | Swagger configuration.                                                                                                    |
- | openapi            | {}       | OpenAPI configuration.                                                                                                    |
- | transform          | null     | Transform method for schema.                                                                                              |
- | uiConfig*          | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
- | initOAuth          | {}       | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)      |
- | staticCSP          | false    | Enable CSP Header for static resources.                                                                                   |
- | transformStaticCSP | undefined    | Synchronous function to transform CSP header for static resources if the header has been previously set.                                                                  | 
+ | option             | default   | description                                                                                                               |
+ | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+ | exposeRoute        | false     | Exposes documentation route.                                                                                              |
+ | hiddenTag          | X-HIDDEN  | Tag to control hiding of routes.                                                                                          |
+ | stripBasePath      | true      | Strips base path from routes in docs.                                                                                     |
+ | swagger            | {}        | Swagger configuration.                                                                                                    |
+ | openapi            | {}        | OpenAPI configuration.                                                                                                    |
+ | transform          | null      | Transform method for schema.                                                                                              |
+ | uiConfig*          | {}        | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
+ | initOAuth          | {}        | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)      |
+ | staticCSP          | false     | Enable CSP header for static resources.                                                                                   |
+ | transformStaticCSP | undefined | Synchronous function to transform CSP header for static resources if the header has been previously set.                  | 
 
 > `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ fastify.register(require('fastify-swagger'), {
     docExpansion: 'full',
     deepLinking: false
   },
+  staticCSP: true,
+  transformStaticCSP: (header) => header
   exposeRoute: true
 })
 
@@ -171,16 +173,18 @@ fastify.ready(err => {
 
 ##### options
 
- | option        | default  | description                                                                                                               |
- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
- | exposeRoute   | false    | Exposes documentation route.                                                                                              |
- | hiddenTag     | X-HIDDEN | Tag to control hiding of routes.                                                                                          |
- | stripBasePath | true     | Strips base path from routes in docs.                                                                                     |
- | swagger       | {}       | Swagger configuration.                                                                                                    |
- | openapi       | {}       | OpenAPI configuration.                                                                                                    |
- | transform     | null     | Transform method for schema.                                                                                              |
- | uiConfig*     | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
- | initOAuth     | {}       | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)
+ | option             | default  | description                                                                                                               |
+ | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+ | exposeRoute        | false    | Exposes documentation route.                                                                                              |
+ | hiddenTag          | X-HIDDEN | Tag to control hiding of routes.                                                                                          |
+ | stripBasePath      | true     | Strips base path from routes in docs.                                                                                     |
+ | swagger            | {}       | Swagger configuration.                                                                                                    |
+ | openapi            | {}       | OpenAPI configuration.                                                                                                    |
+ | transform          | null     | Transform method for schema.                                                                                              |
+ | uiConfig*          | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
+ | initOAuth          | {}       | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)      |
+ | staticCSP          | false    | Enable CSP Header for static resources.                                                                                   |
+ | transformStaticCSP | false    | Transform CSP Header for static resources if exist only.                                                                  | 
 
 > `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ fastify.ready(err => {
  | uiConfig*          | {}       | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) |
  | initOAuth          | {}       | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)      |
  | staticCSP          | false    | Enable CSP Header for static resources.                                                                                   |
- | transformStaticCSP | false    | Transform CSP Header for static resources if exist only.                                                                  | 
+ | transformStaticCSP | undefined    | Synchronous function to transform CSP header for static resources if the header has been previously set.                                                                  | 
 
 > `uiConfig` accepts only literal (number/string/object) configuration values since they are serialized in order to pass them to the generated UI. For more details see: [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,11 @@ export interface FastifySwaggerOptions {
     useBasicAuthenticationWithAccessCodeGrant: boolean,
     usePkceWithAuthorizationCodeGrant: boolean
   }>
+  /**
+   * CSP Config
+   */
+  staticCSP?: boolean | string | Record<string, string | string[]>
+  transformStaticCSP?: (header: string) => string
 }
 
 export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -18,7 +18,9 @@ module.exports = function (fastify, opts, done) {
     const prefix = opts.routePrefix || '/documentation'
     const uiConfig = opts.uiConfig || {}
     const initOAuth = opts.initOAuth || {}
-    fastify.register(require('../routes'), { prefix, uiConfig, initOAuth })
+    const staticCSP = opts.staticCSP
+    const transformStaticCSP = opts.transformStaticCSP
+    fastify.register(require('../routes'), { prefix, uiConfig, initOAuth, staticCSP, transformStaticCSP })
   }
 
   const cache = {

--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -63,7 +63,9 @@ module.exports = function (fastify, opts, done) {
       prefix: opts.routePrefix || '/documentation',
       uiConfig: opts.uiConfig || {},
       initOAuth: opts.initOAuth || {},
-      baseDir: opts.specification.baseDir
+      baseDir: opts.specification.baseDir,
+      staticCSP: opts.staticCSP,
+      transformStaticCSP: opts.transformStaticCSP
     }
 
     fastify.register(require('../routes'), options)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -20,6 +20,35 @@ function getRedirectPathForTheRootRoute (url) {
 }
 
 function fastifySwagger (fastify, opts, done) {
+  let staticCSP = false
+  if (opts.staticCSP === true) {
+    const csp = require('../static/csp.json')
+    staticCSP = `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline' ${csp.style.join(' ')}; upgrade-insecure-requests;`
+  }
+  if (typeof opts.staticCSP === 'string') {
+    staticCSP = opts.staticCSP
+  }
+  if (typeof opts.staticCSP === 'object' && opts.staticCSP !== null) {
+    staticCSP = ''
+    Object.keys(opts.staticCSP).forEach(function (key) {
+      const value = Array.isArray(opts.staticCSP[key]) ? opts.staticCSP[key].join(' ') : opts.staticCSP[key]
+      staticCSP += `${key.toLowerCase()} ${value}; `
+    })
+  }
+
+  fastify.addHook('onSend', function (request, reply, payload, done) {
+    // set static csp when it is passed
+    if (typeof staticCSP === 'string') {
+      reply.header('content-security-policy', staticCSP.trim())
+    }
+    // mutate the header when it is passed
+    const header = reply.getHeader('content-security-policy')
+    if (header && typeof opts.transformStaticCSP === 'function') {
+      reply.header('content-security-policy', opts.transformStaticCSP(header))
+    }
+    done()
+  })
+
   fastify.route({
     url: '/',
     method: 'GET',

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -36,18 +36,20 @@ function fastifySwagger (fastify, opts, done) {
     })
   }
 
-  fastify.addHook('onSend', function (request, reply, payload, done) {
-    // set static csp when it is passed
-    if (typeof staticCSP === 'string') {
-      reply.header('content-security-policy', staticCSP.trim())
-    }
-    // mutate the header when it is passed
-    const header = reply.getHeader('content-security-policy')
-    if (header && typeof opts.transformStaticCSP === 'function') {
-      reply.header('content-security-policy', opts.transformStaticCSP(header))
-    }
-    done()
-  })
+  if (typeof staticCSP === 'string' || typeof opts.transformStaticCSP === 'function') {
+    fastify.addHook('onSend', function (request, reply, payload, done) {
+      // set static csp when it is passed
+      if (typeof staticCSP === 'string') {
+        reply.header('content-security-policy', staticCSP.trim())
+      }
+      // mutate the header when it is passed
+      const header = reply.getHeader('content-security-policy')
+      if (header && typeof opts.transformStaticCSP === 'function') {
+        reply.header('content-security-policy', opts.transformStaticCSP(header))
+      }
+      done()
+    })
+  }
 
   fastify.route({
     url: '/',

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -23,7 +23,7 @@ function fastifySwagger (fastify, opts, done) {
   let staticCSP = false
   if (opts.staticCSP === true) {
     const csp = require('../static/csp.json')
-    staticCSP = `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline' ${csp.style.join(' ')}; upgrade-insecure-requests;`
+    staticCSP = `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(' ')}; upgrade-insecure-requests;`
   }
   if (typeof opts.staticCSP === 'string') {
     staticCSP = opts.staticCSP

--- a/test/csp.js
+++ b/test/csp.js
@@ -1,0 +1,240 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const fastifyHelmet = require('fastify-helmet')
+const fastifySwagger = require('../index')
+const {
+  schemaQuerystring,
+  schemaBody,
+  schemaParams,
+  schemaSecurity
+} = require('../examples/options')
+let {
+  swaggerOption
+} = require('../examples/options')
+const csp = require('../static/csp.json')
+
+// const resolve = require('path').resolve
+// const readFileSync = require('fs').readFileSync
+
+swaggerOption = {
+  ...swaggerOption,
+  exposeRoute: true
+}
+
+test('staticCSP = undefined', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, swaggerOption)
+
+  fastify.get('/', () => {})
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(typeof res.headers['content-security-policy'], 'undefined')
+    t.equal(typeof res.payload, 'string')
+  })
+})
+
+test('staticCSP = true', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    ...swaggerOption,
+    staticCSP: true
+  })
+
+  fastify.get('/', () => { return '' })
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline' ${csp.style.join(' ')}; upgrade-insecure-requests;`)
+    t.equal(typeof res.payload, 'string')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(typeof res.headers['content-security-policy'], 'undefined')
+  })
+})
+
+test('staticCSP = "default-src \'self\';"', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    ...swaggerOption,
+    staticCSP: "default-src 'self';"
+  })
+
+  fastify.get('/', () => { return '' })
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], "default-src 'self';")
+    t.equal(typeof res.payload, 'string')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(typeof res.headers['content-security-policy'], 'undefined')
+  })
+})
+
+test('staticCSP = object', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    ...swaggerOption,
+    staticCSP: {
+      'default-src': ["'self'"],
+      'script-src': "'self'"
+    }
+  })
+
+  fastify.get('/', () => { return '' })
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
+    t.equal(typeof res.payload, 'string')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(typeof res.headers['content-security-policy'], 'undefined')
+  })
+})
+
+test('transformStaticCSP = function', t => {
+  t.plan(8)
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    ...swaggerOption,
+    staticCSP: "default-src 'self';",
+    transformStaticCSP: function (header) {
+      t.equal(header, "default-src 'self';")
+      return "default-src 'self'; script-src 'self';"
+    }
+  })
+
+  fastify.get('/', () => { return '' })
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
+    t.equal(typeof res.payload, 'string')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(typeof res.headers['content-security-policy'], 'undefined')
+  })
+})
+
+test('transformStaticCSP = function, with fastify-helmet', t => {
+  t.plan(8)
+
+  const fastify = Fastify()
+  fastify.register(fastifyHelmet)
+  fastify.register(fastifySwagger, {
+    ...swaggerOption,
+    transformStaticCSP: function (header) {
+      t.equal(header, "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests")
+      return "default-src 'self'; script-src 'self';"
+    }
+  })
+
+  fastify.get('/', () => { return '' })
+  fastify.post('/', () => {})
+  fastify.get('/example', schemaQuerystring, () => {})
+  fastify.post('/example', schemaBody, () => {})
+  fastify.get('/parameters/:id', schemaParams, () => {})
+  fastify.get('/example1', schemaSecurity, () => {})
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/index.html'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
+    t.equal(typeof res.payload, 'string')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-security-policy'], "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests")
+  })
+})

--- a/test/csp.js
+++ b/test/csp.js
@@ -16,9 +16,6 @@ let {
 } = require('../examples/options')
 const csp = require('../static/csp.json')
 
-// const resolve = require('path').resolve
-// const readFileSync = require('fs').readFileSync
-
 swaggerOption = {
   ...swaggerOption,
   exposeRoute: true

--- a/test/csp.js
+++ b/test/csp.js
@@ -67,7 +67,7 @@ test('staticCSP = true', t => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.equal(res.headers['content-security-policy'], `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline' ${csp.style.join(' ')}; upgrade-insecure-requests;`)
+    t.equal(res.headers['content-security-policy'], `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(' ')}; upgrade-insecure-requests;`)
     t.equal(typeof res.payload, 'string')
   })
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -130,3 +130,37 @@ app.register(fastifySwagger, {
 .ready((err) => {
   app.swagger();
 })
+
+app.register(fastifySwagger, {
+  staticCSP: true,
+})
+.ready((err) => {
+  app.swagger();
+})
+
+app.register(fastifySwagger, {
+  staticCSP: "default-src: 'self'",
+})
+.ready((err) => {
+  app.swagger();
+})
+
+app.register(fastifySwagger, {
+  staticCSP: {
+    'default-src': "'self'",
+    'script-src': ["'self'"]
+  },
+})
+.ready((err) => {
+  app.swagger();
+})
+
+app.register(fastifySwagger, {
+  staticCSP: true,
+  transformStaticCSP(header) {
+    return header
+  }
+})
+.ready((err) => {
+  app.swagger();
+})


### PR DESCRIPTION
Resolve: #397 

Changes:
- introduces two new  options `staticCSP` and `transformStaticCSP`.

I am thinking of should we set `staticCSP` default as `true`. So, it can works with `fastify-helmet` out-of-the-box. It would be a `semver-major` if we do this.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
