### PR TITLE
added option to hide untagged routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ fastify.ready(err => {
  | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
  | exposeRoute        | false     | Exposes documentation route.                                                                                              |
  | hiddenTag          | X-HIDDEN  | Tag to control hiding of routes.                                                                                          |
+ | hideUntagged       | false     | If true remove routes without tags in schema from resulting swagger file                                                  |
  | stripBasePath      | true      | Strips base path from routes in docs.                                                                                     |
  | swagger            | {}        | Swagger configuration.                                                                                                    |
  | openapi            | {}        | OpenAPI configuration.                                                                                                    |

--- a/examples/dynamic-openapi.js
+++ b/examples/dynamic-openapi.js
@@ -22,6 +22,7 @@ fastify.register(require('../index'), {
       }
     }
   },
+  hideUntagged: true,
   exposeRoute: true
 })
 
@@ -29,6 +30,44 @@ fastify.put('/some-route/:id', {
   schema: {
     description: 'post some data',
     tags: ['user', 'code'],
+    summary: 'qwerty',
+    security: [{ apiKey: [] }],
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'user id'
+        }
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        hello: { type: 'string' },
+        obj: {
+          type: 'object',
+          properties: {
+            some: { type: 'string' }
+          }
+        }
+      }
+    },
+    response: {
+      201: {
+        description: 'Succesful response',
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
+      }
+    }
+  }
+}, (req, reply) => { reply.send({ hello: `Hello ${req.body.hello}` }) })
+
+fastify.post('/some-route/:id', {
+  schema: {
+    description: 'post some data',
     summary: 'qwerty',
     security: [{ apiKey: [] }],
     params: {

--- a/examples/dynamic-swagger.js
+++ b/examples/dynamic-swagger.js
@@ -21,6 +21,7 @@ fastify.register(require('../index'), {
     consumes: ['application/json'],
     produces: ['application/json']
   },
+  hideUntagged: true,
   exposeRoute: true
 })
 
@@ -28,6 +29,44 @@ fastify.put('/some-route/:id', {
   schema: {
     description: 'post some data',
     tags: ['user', 'code'],
+    summary: 'qwerty',
+    security: [{ apiKey: [] }],
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'user id'
+        }
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        hello: { type: 'string' },
+        obj: {
+          type: 'object',
+          properties: {
+            some: { type: 'string' }
+          }
+        }
+      }
+    },
+    response: {
+      201: {
+        description: 'Succesful response',
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
+      }
+    }
+  }
+}, (req, reply) => { reply.send({ hello: `Hello ${req.body.hello}` }) })
+
+fastify.post('/some-route/:id', {
+  schema: {
+    description: 'post some data',
     summary: 'qwerty',
     security: [{ apiKey: [] }],
     params: {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -8,6 +8,7 @@ module.exports = function (fastify, opts, done) {
   opts = Object.assign({}, {
     exposeRoute: false,
     hiddenTag: 'X-HIDDEN',
+    hideUntagged: false,
     stripBasePath: true,
     openapi: null,
     swagger: {},

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -36,7 +36,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
         ? defOpts.transform(route.schema)
         : route.schema
 
-      if (shouldRouteHide(schema, defOpts.hiddenTag)) continue
+      if (shouldRouteHide(schema, defOpts.hiddenTag, defOpts.hideUntagged)) continue
 
       const url = normalizeUrl(route.url, defOpts.servers, defOpts.stripBasePath)
 

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -36,7 +36,12 @@ module.exports = function (opts, cache, routes, Ref, done) {
         ? defOpts.transform(route.schema)
         : route.schema
 
-      if (shouldRouteHide(schema, defOpts.hiddenTag, defOpts.hideUntagged)) continue
+      const shouldRouteHideOpts = {
+        hiddenTag: defOpts.hiddenTag,
+        hideUntagged: defOpts.hideUntagged
+      }
+
+      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
 
       const url = normalizeUrl(route.url, defOpts.servers, defOpts.stripBasePath)
 

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -15,6 +15,7 @@ function prepareDefaultOptions (opts) {
   const stripBasePath = opts.stripBasePath
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
+  const hideUntagged = opts.hideUntagged
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.openapi)) {
@@ -33,7 +34,8 @@ function prepareDefaultOptions (opts) {
     stripBasePath,
     transform,
     hiddenTag,
-    extensions
+    extensions,
+    hideUntagged
   }
 }
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -36,7 +36,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
         ? defOpts.transform(route.schema)
         : route.schema
 
-      if (shouldRouteHide(schema, defOpts.hiddenTag)) continue
+      if (shouldRouteHide(schema, defOpts.hiddenTag, defOpts.hideUntagged)) continue
 
       const url = normalizeUrl(route.url, defOpts.basePath, defOpts.stripBasePath)
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -36,7 +36,12 @@ module.exports = function (opts, cache, routes, Ref, done) {
         ? defOpts.transform(route.schema)
         : route.schema
 
-      if (shouldRouteHide(schema, defOpts.hiddenTag, defOpts.hideUntagged)) continue
+      const shouldRouteHideOpts = {
+        hiddenTag: defOpts.hiddenTag,
+        hideUntagged: defOpts.hideUntagged
+      }
+
+      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
 
       const url = normalizeUrl(route.url, defOpts.basePath, defOpts.stripBasePath)
 

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -19,6 +19,7 @@ function prepareDefaultOptions (opts) {
   const stripBasePath = opts.stripBasePath
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
+  const hideUntagged = opts.hideUntagged
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.swagger)) {
@@ -42,7 +43,8 @@ function prepareDefaultOptions (opts) {
     stripBasePath,
     transform,
     hiddenTag,
-    extensions
+    extensions,
+    hideUntagged
   }
 }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -41,7 +41,9 @@ function addHook (fastify) {
   }
 }
 
-function shouldRouteHide (schema, hiddenTag, hideUntagged) {
+function shouldRouteHide (schema, opts) {
+  const { hiddenTag, hideUntagged } = opts
+
   if (schema && schema.hide) {
     return true
   }
@@ -52,9 +54,10 @@ function shouldRouteHide (schema, hiddenTag, hideUntagged) {
     return true
   }
 
-  if (schema && schema.tags && schema.tags.includes(hiddenTag)) {
+  if (tags.includes(hiddenTag)) {
     return schema.tags.includes(hiddenTag)
   }
+
   return false
 }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -41,10 +41,17 @@ function addHook (fastify) {
   }
 }
 
-function shouldRouteHide (schema, hiddenTag) {
+function shouldRouteHide (schema, hiddenTag, hideUntagged) {
   if (schema && schema.hide) {
     return true
   }
+
+  const tags = (schema && schema.tags) || []
+
+  if (tags.length === 0 && hideUntagged) {
+    return true
+  }
+
   if (schema && schema.tags && schema.tags.includes(hiddenTag)) {
     return schema.tags.includes(hiddenTag)
   }

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -213,6 +213,39 @@ test('hide support - tags Custom', t => {
   })
 })
 
+test('hide support - hidden untagged', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, { ...openapiOption, hideUntagged: true })
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' },
+          obj: {
+            type: 'object',
+            properties: {
+              some: { type: 'string' }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.notOk(openapiObject.paths['/'])
+  })
+})
+
 test('basePath support', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -386,6 +386,39 @@ test('hide support - tags Custom', t => {
   })
 })
 
+test('hide support - hidden untagged', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, { ...swaggerOption, hideUntagged: true })
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' },
+          obj: {
+            type: 'object',
+            properties: {
+              some: { type: 'string' }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.notOk(openapiObject.paths['/'])
+  })
+})
+
 test('cache - json', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -414,8 +414,8 @@ test('hide support - hidden untagged', t => {
   fastify.ready(err => {
     t.error(err)
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/'])
+    const swaggerObject = fastify.swagger()
+    t.notOk(swaggerObject.paths['/'])
   })
 })
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Added a new plugin parameter **hideUntagged**.
Added cases in both dynamic swagger and openapi example
Added tests cases in both dynamic swagger and openapi
Update readme with the new parameter description

Related issue: https://github.com/fastify/fastify-swagger/issues/403