### PR TITLE
Avoid inline script execution

### DIFF
--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -24,8 +24,10 @@ filesToCopy.forEach(filename => {
 })
 
 const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
-  .replace(/<script>((.| |\n)*)<\/script>/, `
-  <script>
+  .replace(/<script>((.| |\n)*)<\/script>/, '<script src="./swagger-ui-init.js" charset="UTF-8"> </script>')
+fse.writeFileSync(resolve('./static/index.html'), newIndex)
+
+const newInit = `
   window.onload = function () {
     function resolveUrl (url) {
         const anchor = document.createElement('a')
@@ -74,10 +76,8 @@ const newIndex = fs.readFileSync(resolve('./static/index.html'), 'utf8')
 
     resolveConfig(buildUi);
   }
-  </script>
-  `)
-
-fse.writeFileSync(resolve('./static/index.html'), newIndex)
+`
+fse.writeFileSync(resolve('./static/swagger-ui-init.js'), newInit)
 
 const sha = {
   script: [],

--- a/test/route.js
+++ b/test/route.js
@@ -362,7 +362,7 @@ test('with routePrefix: \'/\' should redirect to ./static/index.html', t => {
 })
 
 test('/documentation/static/:file should send back the correct file', t => {
-  t.plan(24)
+  t.plan(29)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerOption)
@@ -398,8 +398,25 @@ test('/documentation/static/:file should send back the correct file', t => {
         ),
         res.payload
       )
-      t.ok(res.payload.indexOf('resolveUrl') !== -1)
+      t.ok(res.payload.indexOf('swagger-ui-init.js') !== -1)
     })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/swagger-ui-init.js'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(typeof res.payload, 'string')
+    t.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8')
+    t.equal(
+      readFileSync(
+        resolve(__dirname, '..', 'static', 'swagger-ui-init.js'),
+        'utf8'
+      ),
+      res.payload
+    )
+    t.ok(res.payload.indexOf('resolveUrl') !== -1)
   })
 
   fastify.inject({


### PR DESCRIPTION
Chrome refuses to execute inline scripts when certain headers are set.
This is simple to avoid by moving the init script into a separate file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
