### PR TITLE
Add OpenAPI Links support

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,74 @@ Will generate this in the OpenAPI v3 schema's `paths`:
 }
 ```
 
+<a name="route.links"></a>
+#### Links
+
+**Note:** not supported by Swagger (OpenAPI v2), [only OpenAPI v3](https://swagger.io/docs/specification/links/)
+
+OpenAPI v3 Links are added by adding a `links` property to the top-level options of a route. See:
+
+```js
+fastify.get('/user/:id', {
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'the user identifier, as userId'
+        }
+      },
+      required: ['id']
+    },
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          uuid: {
+            type: 'string',
+            format: 'uuid'
+          }
+        }
+      }
+    }
+  },
+  links: {
+    // The status code must match the one in the response
+    200: {
+      address: {
+        // See the OpenAPI documentation
+        operationId: 'getUserAddress',
+        parameters: {
+          id: '$request.path.id'
+        }
+      }
+    }
+  }
+}, () => {})
+
+fastify.get('/user/:id/address', {
+  schema: {
+    operationId: 'getUserAddress',
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'the user identifier, as userId'
+        }
+      },
+      required: ['id']
+    },
+    response: {
+      200: {
+        type: 'string'
+      }
+    }
+  }
+}, () => {})
+```
+
 <a name="route.hide"></a>
 #### Hide a route
 There are two ways to hide a route from the Swagger UI:

--- a/examples/options.js
+++ b/examples/options.js
@@ -230,6 +230,24 @@ const schemaExtension = {
   }
 }
 
+const schemaOperationId = {
+  schema: {
+    operationId: 'helloWorld',
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            description: 'hello',
+            type: 'string'
+          }
+        },
+        required: ['hello']
+      }
+    }
+  }
+}
+
 module.exports = {
   openapiOption,
   swaggerOption,
@@ -243,5 +261,6 @@ module.exports = {
   schemaProduces,
   schemaCookies,
   schemaAllOf,
-  schemaExtension
+  schemaExtension,
+  schemaOperationId
 }

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -49,6 +49,15 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const openapiMethod = prepareOpenapiMethod(schema, ref, openapiObject)
 
+      if (route.links) {
+        for (const statusCode of Object.keys(route.links)) {
+          if (!openapiMethod.responses[statusCode]) {
+            throw new Error(`missing status code ${statusCode} in route ${route.path}`)
+          }
+          openapiMethod.responses[statusCode].links = route.links[statusCode]
+        }
+      }
+
       // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
       const methods = typeof route.method === 'string' ? [route.method] : route.method
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -49,6 +49,10 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const swaggerMethod = prepareSwaggerMethod(schema, ref, swaggerObject)
 
+      if (route.links) {
+        throw new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see fastify-swagger readme)')
+      }
+
       // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
       const methods = typeof route.method === 'string' ? [route.method] : route.method
 

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -693,6 +693,6 @@ test('links without status code', t => {
 
   fastify.ready(err => {
     t.error(err)
-    t.throws(() => fastify.swagger(), 'missing status code 201 in route /user/:id')
+    t.throws(() => fastify.swagger(), new Error('missing status code 201 in route /user/:id'))
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

As titled, this PR adds support for OpenAPI Links. This feature is OpenAPI v3 specific.
I did a somewhat different approach as it is not part of the schema.
Let me know if the place where I put those new options is ok or not.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
