### PR TITLE
fix: single value examples should be converted to example

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -83,6 +83,8 @@ function transformDefsToComponents (jsonSchema) {
     Object.keys(jsonSchema).forEach(function (key) {
       if (key === '$ref') {
         jsonSchema[key] = jsonSchema[key].replace('definitions', 'components/schemas')
+      } else if (key === 'examples' && Array.isArray(jsonSchema[key]) && (jsonSchema[key].length > 1)) {
+        jsonSchema.examples = convertExamplesArrayToObject(jsonSchema.examples)
       } else if (key === 'examples' && Array.isArray(jsonSchema[key]) && (jsonSchema[key].length === 1)) {
         jsonSchema.example = jsonSchema[key][0]
         delete jsonSchema[key]
@@ -92,6 +94,18 @@ function transformDefsToComponents (jsonSchema) {
     })
   }
   return jsonSchema
+}
+
+function convertExamplesArrayToObject (examples) {
+  return examples.reduce((examplesObject, example, index) => {
+    if (typeof example === 'object') {
+      examplesObject['key' + index] = { value: example }
+    } else {
+      examplesObject[example] = { value: example }
+    }
+
+    return examplesObject
+  }, {})
 }
 
 // For supported keys read:

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -83,6 +83,9 @@ function transformDefsToComponents (jsonSchema) {
     Object.keys(jsonSchema).forEach(function (key) {
       if (key === '$ref') {
         jsonSchema[key] = jsonSchema[key].replace('definitions', 'components/schemas')
+      } else if (key === 'examples' && Array.isArray(jsonSchema[key]) && (jsonSchema[key].length === 1)) {
+        jsonSchema.example = jsonSchema[key][0]
+        delete jsonSchema[key]
       } else {
         jsonSchema[key] = transformDefsToComponents(jsonSchema[key])
       }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -99,7 +99,7 @@ function transformDefsToComponents (jsonSchema) {
 function convertExamplesArrayToObject (examples) {
   return examples.reduce((examplesObject, example, index) => {
     if (typeof example === 'object') {
-      examplesObject['key' + index] = { value: example }
+      examplesObject['example' + (index + 1)] = { value: example }
     } else {
       examplesObject[example] = { value: example }
     }

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -344,4 +344,79 @@ test('cache - yaml', t => {
   })
 })
 
+test('transforms examples in example if single string example', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'string',
+            examples: ['world']
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.notOk(schema.properties.hello.examples)
+    t.equal(schema.properties.hello.example, 'world')
+  })
+})
+
+test('transforms examples in example if single object example', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'object',
+            properties: {
+              lorem: {
+                type: 'string'
+              }
+            },
+            examples: [{ lorem: 'ipsum' }]
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.notOk(schema.properties.hello.examples)
+    t.same(schema.properties.hello.example, { lorem: 'ipsum' })
+  })
+})
+
 module.exports = { openapiOption }

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -419,4 +419,79 @@ test('transforms examples in example if single object example', t => {
   })
 })
 
+test('uses examples if has multiple string examples', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'string',
+            examples: ['hello', 'world']
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.ok(schema.properties.hello.examples)
+    t.same(schema.properties.hello.examples, ['hello', 'world'])
+  })
+})
+
+test('uses examples if has multiple object examples', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'object',
+            properties: {
+              lorem: {
+                type: 'string'
+              }
+            },
+            examples: [{ lorem: 'ipsum' }, { hello: 'world' }]
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.ok(schema.properties.hello.examples)
+    t.same(schema.properties.hello.examples, [{ lorem: 'ipsum' }, { hello: 'world' }])
+  })
+})
+
 module.exports = { openapiOption }

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -450,7 +450,14 @@ test('uses examples if has multiple string examples', t => {
 
     t.ok(schema)
     t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, ['hello', 'world'])
+    t.same(schema.properties.hello.examples, {
+      hello: {
+        value: 'hello'
+      },
+      world: {
+        value: 'world'
+      }
+    })
   })
 })
 
@@ -490,7 +497,113 @@ test('uses examples if has multiple object examples', t => {
 
     t.ok(schema)
     t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, [{ lorem: 'ipsum' }, { hello: 'world' }])
+    t.same(schema.properties.hello.examples, {
+      key0: {
+        value: {
+          lorem: 'ipsum'
+        }
+      },
+      key1: {
+        value: {
+          hello: 'world'
+        }
+      }
+    })
+  })
+})
+
+test('uses examples if has multiple array examples', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            examples: [['a', 'b', 'c'], ['d', 'f', 'g']]
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.ok(schema.properties.hello.examples)
+    t.same(schema.properties.hello.examples, {
+      key0: {
+        value: [
+          'a',
+          'b',
+          'c'
+        ]
+      },
+      key1: {
+        value: [
+          'd',
+          'f',
+          'g'
+        ]
+      }
+    })
+  })
+})
+
+test('uses examples if has multiple numbers examples', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'number',
+            examples: [1, 2]
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.ok(schema.properties.hello.examples)
+    t.same(schema.properties.hello.examples, {
+      1: {
+        value: 1
+      },
+      2: {
+        value: 2
+      }
+    })
   })
 })
 

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -461,6 +461,48 @@ test('uses examples if has multiple string examples', t => {
   })
 })
 
+test('uses examples if has multiple numbers examples', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'number',
+            examples: [1, 2]
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+
+    t.ok(schema)
+    t.ok(schema.properties.hello.examples)
+    t.same(schema.properties.hello.examples, {
+      1: {
+        value: 1
+      },
+      2: {
+        value: 2
+      }
+    })
+  })
+})
+
 test('uses examples if has multiple object examples', t => {
   t.plan(4)
   const fastify = Fastify()
@@ -498,12 +540,12 @@ test('uses examples if has multiple object examples', t => {
     t.ok(schema)
     t.ok(schema.properties.hello.examples)
     t.same(schema.properties.hello.examples, {
-      key0: {
+      example1: {
         value: {
           lorem: 'ipsum'
         }
       },
-      key1: {
+      example2: {
         value: {
           hello: 'world'
         }
@@ -547,61 +589,19 @@ test('uses examples if has multiple array examples', t => {
     t.ok(schema)
     t.ok(schema.properties.hello.examples)
     t.same(schema.properties.hello.examples, {
-      key0: {
+      example1: {
         value: [
           'a',
           'b',
           'c'
         ]
       },
-      key1: {
+      example2: {
         value: [
           'd',
           'f',
           'g'
         ]
-      }
-    })
-  })
-})
-
-test('uses examples if has multiple numbers examples', t => {
-  t.plan(4)
-  const fastify = Fastify()
-
-  fastify.register(fastifySwagger, openapiOption)
-
-  const opts = {
-    schema: {
-      body: {
-        type: 'object',
-        required: ['hello'],
-        properties: {
-          hello: {
-            type: 'number',
-            examples: [1, 2]
-          }
-        }
-      }
-    }
-  }
-
-  fastify.get('/', opts, () => {})
-
-  fastify.ready(err => {
-    t.error(err)
-
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
-
-    t.ok(schema)
-    t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, {
-      1: {
-        value: 1
-      },
-      2: {
-        value: 2
       }
     })
   })


### PR DESCRIPTION
Changes:
- For single value `examples` it should be converted to `example` object

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer’s Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fastify-swagger/issues/421