### PR TITLE
Add support for $ref in header schemas

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -158,7 +158,7 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
       break
     case 'header':
       toOpenapiProp = function (propertyName, jsonSchemaElement) {
-        return {
+        const result = {
           in: 'header',
           name: propertyName,
           required: jsonSchemaElement.required,
@@ -167,6 +167,9 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
             type: jsonSchemaElement.type
           }
         }
+
+        if (jsonSchemaElement.$ref) result.schema.$ref = jsonSchemaElement.$ref
+        return result
       }
       break
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Greetings!

First of all, thanks for all the work on the fastify ecosystem. It's a blast to utilise it in projects.

This PR includes a small adjustment to the way `header`s are treated in `plainJsonObjectToOpenapi3`.

The motivation is a scenario from my setup, where I attach some headers validation to most of my routes. They contain either `enum`s or `example`s that I'd like to be properly passed down to the resulting OpenAPI schema. One of the benefits of this is, in tandem with properly initialising refs, to have its presentation in `swagger-ui` improved: select fields for `enum` etc.

I first experimented with injecting `example` and `examples` fields directly into the value returned from `toOpenapiProp`, however I think the approach with `$ref` is both more elegant and functional.

Please let me know whether: my suggestion is too narrow or not, and is the added test sufficient enough.

 I'm also wondering 
 - if it shouldn't search for `$ref` within an additional `schema` property,
 - whether the `type` field next to possible `$ref` should now be optional or not - best case scenario I'd like to define the `$ref` only; same goes for `description`?

PS: isn't the PR template outdated? I see no `benchmark` script in `package.json`.

Cheers!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
