### PR TITLE
fix(openapi): fix global schema references in fastify

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -198,7 +198,15 @@ function resolveBodyParams (content, schema, consumes, ref) {
 }
 
 function resolveCommonParams (container, parameters, schema, ref, sharedSchemas) {
-  const resolved = transformDefsToComponents(ref.resolve(schema))
+  const schemasPath = '#/components/schemas/'
+  let resolved = transformDefsToComponents(ref.resolve(schema))
+
+  // if the resolved definition is in global schema
+  if (resolved.$ref && resolved.$ref.startsWith(schemasPath)) {
+    const parts = resolved.$ref.split(schemasPath)
+    resolved = ref.definitions().definitions[parts[1]]
+  }
+
   const arr = plainJsonObjectToOpenapi3(container, resolved, sharedSchemas)
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -253,3 +253,22 @@ test('support default=null', async t => {
   const definedPath = api.paths['/'].get
   t.same(definedPath.responses['2XX'].default, null)
 })
+
+test('support global schema reference', async t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    },
+    required: ['hello']
+  }
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
+  fastify.addSchema({ ...schema, $id: 'requiredUniqueSchema' })
+  fastify.get('/', { schema: { query: { $ref: 'requiredUniqueSchema' } } }, () => {})
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+  t.same(api.components.schemas['def-0'], schema)
+})


### PR DESCRIPTION
Initially solved by @schantaraud, and referenced in https://github.com/fastify/fastify-swagger/pull/395, I've added tests specifically for this and solved #394 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
