### PR TITLE
Allows to define empty response body for any status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,9 +388,9 @@ You can decorate your own response headers by following the below example:
 ```
 Note: You need to specify `type` property when you decorate the response headers, otherwise the schema will be modified by Fastify.
 
-<a name="route.response.204"></a>
-##### Status code 204
-Status code 204 is supported by `fastify-swagger` and returns an empty body.
+<a name="route.response.empty_body"></a>
+##### Empty Body Responses
+Empty body responses are supported by `fastify-swagger`.
 Please specify `type: 'null'` for the response otherwise Fastify itself will fail to compile the schema:
 
 ```js
@@ -399,6 +399,10 @@ Please specify `type: 'null'` for the response otherwise Fastify itself will fai
     204: {
       type: 'null',
       description: 'No Content'
+    },
+    503: {
+      type: 'null',
+      description: 'Service Unavailable'
     }
   }
 }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -253,7 +253,8 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
       delete resolved.headers
     }
 
-    if (statusCode.toString() !== '204') {
+    // add schema when type is not 'null'
+    if (rawJsonSchema.type !== 'null') {
       const content = {}
 
       if ((Array.isArray(produces) && produces.length === 0) || typeof produces === 'undefined') {

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -213,8 +213,8 @@ function resolveResponse (fastifyResponseJson, ref) {
       delete resolved.headers
     }
 
-    // add schema when status code is not 204
-    if (statusCode.toString() !== '204') {
+    // add schema when type is not 'null'
+    if (rawJsonSchema.type !== 'null') {
       const schema = { ...resolved }
       delete schema[xResponseDescription]
       response.schema = schema

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -103,6 +103,44 @@ test('support status code 204', async t => {
   t.notOk(definedPath.responses['204'].content)
 })
 
+test('support empty response body for different status than 204', async t => {
+  const opt = {
+    schema: {
+      response: {
+        204: {
+          type: 'null',
+          description: 'No Content'
+        },
+        503: {
+          type: 'null',
+          description: 'Service Unavailable'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    openapi: true,
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+
+  t.same(definedPath.responses['204'].description, 'No Content')
+  t.notOk(definedPath.responses['204'].content)
+
+  t.same(definedPath.responses['503'].description, 'Service Unavailable')
+  t.notOk(definedPath.responses['503'].content)
+})
+
 test('support response headers', async t => {
   const opt = {
     schema: {

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -191,6 +191,45 @@ test('support status code 204', async t => {
   t.notOk(definedPath.responses['204'].schema)
 })
 
+test('support empty response body for different status than 204', async t => {
+  const opt = {
+    schema: {
+      response: {
+        204: {
+          type: 'null',
+          description: 'No Content'
+        },
+        503: {
+          type: 'null',
+          description: 'Service Unavailable'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+
+  t.same(definedPath.responses['204'].description, 'No Content')
+  t.notOk(definedPath.responses['204'].content)
+  t.notOk(definedPath.responses['503'].type)
+
+  t.same(definedPath.responses['503'].description, 'Service Unavailable')
+  t.notOk(definedPath.responses['503'].content)
+  t.notOk(definedPath.responses['503'].type)
+})
+
 test('support response headers', async t => {
   const opt = {
     schema: {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fastify-swagger/issues/434

OpenAPI generated schema

```yaml
openapi: 3.0.3
info:
  version: 4.8.2
  title: fastify-swagger
components:
  schemas: {}
paths:
  /:
    get:
      responses:
        '204':
          description: No Content
        '503':
          description: Service Unavailable
```

Swagger generated schema
```yaml
swagger: '2.0'
info:
  version: 4.8.2
  title: fastify-swagger
definitions: {}
paths:
  /:
    get:
      responses:
        '204':
          description: No Content
        '503':
          description: Service Unavailable
```