### PR TITLE
All

### DIFF
--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -65,15 +65,17 @@ function shouldRouteHide (schema, opts) {
 // so '/user/:id' is not valid.
 // This function converts the url in a swagger compliant url string
 // => '/user/{id}'
+// custom verbs at the end of a url are okay => /user::watch but should be rendered as /user:watch in swagger
 function formatParamUrl (url) {
-  const regex = /:([a-zA-Z0-9_]+)/g
+  const regex = /(?<!:):([a-zA-Z0-9_]+)/g
   let found = regex.exec(url)
   while (found !== null) {
     const [full, param] = found
     url = url.replace(full, '{' + param + '}')
     found = regex.exec(url)
   }
-  return url
+
+  return url.replace('::', ':')
 }
 
 function resolveLocalRef (jsonSchema, externalSchemas) {

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -300,6 +300,45 @@ test('swagger json output should not omit enum part in params config', t => {
   })
 })
 
+test('custom verbs should not be interpreted as path params', t => {
+  t.plan(3)
+  const opts = {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, swaggerOption)
+  fastify.get('/resource/:id/sub-resource::watch', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    const swaggerObject = fastify.swagger()
+
+    Swagger.validate(swaggerObject)
+      .then((api) => {
+        const definedPath = api.paths['/resource/{id}/sub-resource:watch'].get
+        t.ok(definedPath)
+        t.same(definedPath.parameters, [{
+          in: 'path',
+          name: 'id',
+          type: 'string',
+          required: true
+        }])
+      })
+      .catch(err => {
+        console.log(err)
+        t.error(err)
+      })
+  })
+})
+
 test('swagger json output should not omit consume in querystring schema', async (t) => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
Modify regex for finding path params to ignore path verbs (they start with `::`), and replace `::` with `:`  for final render in swagger.

> If you want a path containing a colon without declaring a parameter, use a double colon. For example:
> `fastify.post('/name::verb') // will be interpreted as /name:verb`

[Fastify docs # UrlBuilding](https://www.fastify.io/docs/latest/Routes/#url-building)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (benchmark command seems missing)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (think it's expected to work based off fastify docs)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
