### PR TITLE
Add validatorUrl to the FastifySwaggerOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export interface FastifySwaggerOptions {
       theme?: string
     } | false
     tryItOutEnabled: boolean
+    validatorUrl: string | null
   }>
   
   initOAuth?: Partial<{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-swagger",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Serve Swagger/OpenAPI documentation for Fastify, supporting dynamic generation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-swagger",
-  "version": "4.8.4",
+  "version": "4.8.3",
   "description": "Serve Swagger/OpenAPI documentation for Fastify, supporting dynamic generation",
   "main": "index.js",
   "scripts": {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -126,7 +126,8 @@ app.register(fastifySwagger, {
   uiConfig: {
     deepLinking: true,
     defaultModelsExpandDepth: -1,
-    defaultModelExpandDepth: 1
+    defaultModelExpandDepth: 1,
+    validatorUrl: null
   }
 })
 .ready((err) => {


### PR DESCRIPTION
No code changes. Just expose an option on the interface to make nice for us ts users.
satisfy #191 
#### Checklist

- [x ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included N/A
- [ ] documentation is changed or added N/A
- [x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
