### PR TITLE
Add support for async transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ If you set `exposeRoute` to `true` the plugin will expose the documentation with
 <a name="register.options.transform"></a>
 #### Transforms
 
-To use different schemas such as [Joi](https://github.com/hapijs/joi) you can pass a synchronous `transform` method in the options to convert them back to standard JSON schemas expected by this plugin to generate the documentation (`dynamic` mode only).
+To use different schemas such as [Joi](https://github.com/hapijs/joi) you can pass a synchronous or asynchronous `transform` method in the options to convert them back to standard JSON schemas expected by this plugin to generate the documentation (`dynamic` mode only).
+
+##### Synchronous transform
 
 ```js
 const convert = require('joi-to-json')
@@ -250,6 +252,30 @@ fastify.register(require('fastify-swagger'), {
     if (params) transformed.params = convert(params)
     if (body) transformed.body = convert(body)
     if (querystring) transformed.querystring = convert(querystring)
+    return transformed
+  }
+}
+```
+
+##### Asynchronous transform
+
+```js
+const convert = require('@openapi-contrib/json-schema-to-openapi-schema')
+
+fastify.register(require('fastify-swagger'), {
+  swagger: { ... },
+  ...
+  transform: async schema => {
+    const {
+      params = undefined,
+      body = undefined,
+      querystring = undefined,
+      ...others
+    } = schema
+    const transformed = { ...others }
+    if (params) transformed.params = await convert(params)
+    if (body) transformed.body = await convert(body)
+    if (querystring) transformed.querystring = await convert(querystring)
     return transformed
   }
 }

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ fastify.register(require('fastify-swagger'), {
 ```
 
 ##### Asynchronous transform
+**NOTE:** When using an async transformer, any calls of `fastify.swagger()` will need to be awaited (or chained  with `.then`) since it will return a Promise instead of just a JSON object.
 
 ```js
 const convert = require('@openapi-contrib/json-schema-to-openapi-schema')

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'fastify' {
       opts?: {
         yaml?: boolean;
       }
-    ) => OpenAPI.Document;
+    ) => OpenAPI.Document | Promise<OpenAPI.Document>;
 
     swaggerCSP: {
       script: string[];
@@ -25,7 +25,7 @@ declare module 'fastify' {
     /**
      * OpenAPI operation unique identifier
      */
-    operationId?: string;    
+    operationId?: string;
   }
 }
 
@@ -99,7 +99,7 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
   /**
    * Overwrite the route schema
    */
-  transform?: Function;
+  transform?: (schema: any) => any | Promise<any>;
 }
 
 export interface StaticPathSpec {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -32,5 +32,13 @@ module.exports = function (fastify, opts, done) {
   const swagger = resolveSwaggerFunction(opts, cache, routes, Ref, done)
   fastify.decorate('swagger', swagger)
 
+  fastify.addHook('onReady', async function () {
+    // "Pre-computes" the swagger object to populate the cache, so that user
+    // doesn't have to await if they use an async transformer.
+    try {
+      await fastify.swagger()
+    } catch {}
+  })
+
   done()
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,155 +1,155 @@
-"use strict";
+'use strict'
 
-const path = require("path");
-const fastifyStatic = require("fastify-static");
+const path = require('path')
+const fastifyStatic = require('fastify-static')
 
 // URI prefix to separate static assets for swagger UI
-const staticPrefix = "/static";
+const staticPrefix = '/static'
 
-function getRedirectPathForTheRootRoute(url) {
-  let redirectPath;
+function getRedirectPathForTheRootRoute (url) {
+  let redirectPath
 
-  if (url.substr(-1) === "/") {
-    redirectPath = `.${staticPrefix}/index.html`;
+  if (url.substr(-1) === '/') {
+    redirectPath = `.${staticPrefix}/index.html`
   } else {
-    const urlPathParts = url.split("/");
+    const urlPathParts = url.split('/')
     redirectPath = `./${
       urlPathParts[urlPathParts.length - 1]
-    }${staticPrefix}/index.html`;
+    }${staticPrefix}/index.html`
   }
 
-  return redirectPath;
+  return redirectPath
 }
 
-function fastifySwagger(fastify, opts, done) {
-  let staticCSP = false;
+function fastifySwagger (fastify, opts, done) {
+  let staticCSP = false
   if (opts.staticCSP === true) {
-    const csp = require("../static/csp.json");
+    const csp = require('../static/csp.json')
     staticCSP = `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(
-      " "
+      ' '
     )}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(
-      " "
-    )}; upgrade-insecure-requests;`;
+      ' '
+    )}; upgrade-insecure-requests;`
   }
-  if (typeof opts.staticCSP === "string") {
-    staticCSP = opts.staticCSP;
+  if (typeof opts.staticCSP === 'string') {
+    staticCSP = opts.staticCSP
   }
-  if (typeof opts.staticCSP === "object" && opts.staticCSP !== null) {
-    staticCSP = "";
+  if (typeof opts.staticCSP === 'object' && opts.staticCSP !== null) {
+    staticCSP = ''
     Object.keys(opts.staticCSP).forEach(function (key) {
       const value = Array.isArray(opts.staticCSP[key])
-        ? opts.staticCSP[key].join(" ")
-        : opts.staticCSP[key];
-      staticCSP += `${key.toLowerCase()} ${value}; `;
-    });
+        ? opts.staticCSP[key].join(' ')
+        : opts.staticCSP[key]
+      staticCSP += `${key.toLowerCase()} ${value}; `
+    })
   }
 
   if (
-    typeof staticCSP === "string" ||
-    typeof opts.transformStaticCSP === "function"
+    typeof staticCSP === 'string' ||
+    typeof opts.transformStaticCSP === 'function'
   ) {
-    fastify.addHook("onSend", function (request, reply, payload, done) {
+    fastify.addHook('onSend', function (request, reply, payload, done) {
       // set static csp when it is passed
-      if (typeof staticCSP === "string") {
-        reply.header("content-security-policy", staticCSP.trim());
+      if (typeof staticCSP === 'string') {
+        reply.header('content-security-policy', staticCSP.trim())
       }
       // mutate the header when it is passed
-      const header = reply.getHeader("content-security-policy");
-      if (header && typeof opts.transformStaticCSP === "function") {
+      const header = reply.getHeader('content-security-policy')
+      if (header && typeof opts.transformStaticCSP === 'function') {
         reply.header(
-          "content-security-policy",
+          'content-security-policy',
           opts.transformStaticCSP(header)
-        );
+        )
       }
-      done();
-    });
+      done()
+    })
   }
 
-  const hooks = Object.create(null);
+  const hooks = Object.create(null)
   if (opts.hooks) {
-    const additionalHooks = ["onRequest", "preHandler"];
+    const additionalHooks = ['onRequest', 'preHandler']
     for (const hook of additionalHooks) {
-      hooks[hook] = opts.hooks[hook];
+      hooks[hook] = opts.hooks[hook]
     }
   }
 
   fastify.route({
-    url: "/",
-    method: "GET",
+    url: '/',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: (req, reply) => {
-      reply.redirect(getRedirectPathForTheRootRoute(req.raw.url));
-    },
-  });
+      reply.redirect(getRedirectPathForTheRootRoute(req.raw.url))
+    }
+  })
 
   fastify.route({
-    url: "/uiConfig",
-    method: "GET",
+    url: '/uiConfig',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: (req, reply) => {
-      reply.send(opts.uiConfig);
-    },
-  });
+      reply.send(opts.uiConfig)
+    }
+  })
 
   fastify.route({
-    url: "/initOAuth",
-    method: "GET",
+    url: '/initOAuth',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: (req, reply) => {
-      reply.send(opts.initOAuth);
-    },
-  });
+      reply.send(opts.initOAuth)
+    }
+  })
 
   fastify.route({
-    url: "/json",
-    method: "GET",
+    url: '/json',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: async function (req, reply) {
-      reply.send(await fastify.swagger());
-    },
-  });
+      reply.send(await fastify.swagger())
+    }
+  })
 
   fastify.route({
-    url: "/yaml",
-    method: "GET",
+    url: '/yaml',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: async function (req, reply) {
-      const spec = await fastify.swagger({ yaml: true });
+      const spec = await fastify.swagger({ yaml: true })
 
-      reply.type("application/x-yaml").send(spec);
-    },
-  });
+      reply.type('application/x-yaml').send(spec)
+    }
+  })
 
   // serve swagger-ui with the help of fastify-static
   fastify.register(fastifyStatic, {
-    root: path.join(__dirname, "..", "static"),
+    root: path.join(__dirname, '..', 'static'),
     prefix: staticPrefix,
-    decorateReply: false,
-  });
+    decorateReply: false
+  })
 
   fastify.register(fastifyStatic, {
-    root: opts.baseDir || path.join(__dirname, ".."),
-    serve: false,
-  });
+    root: opts.baseDir || path.join(__dirname, '..'),
+    serve: false
+  })
 
   // Handler for external documentation files passed via $ref
   fastify.route({
-    url: "/*",
-    method: "GET",
+    url: '/*',
+    method: 'GET',
     schema: { hide: true },
     ...hooks,
     handler: function (req, reply) {
-      const file = req.params["*"];
-      reply.sendFile(file);
-    },
-  });
+      const file = req.params['*']
+      reply.sendFile(file)
+    }
+  })
 
-  done();
+  done()
 }
 
-module.exports = fastifySwagger;
+module.exports = fastifySwagger

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -82,8 +82,10 @@ function fastifySwagger (fastify, opts, done) {
     url: '/json',
     method: 'GET',
     schema: { hide: true },
-    handler: function (req, reply) {
-      reply.send(fastify.swagger())
+    handler: async function (req, reply) {
+      // Handles both sync and async mode (await works on non-Promises)
+      const spec = await fastify.swagger()
+      reply.send(spec)
     }
   })
 
@@ -91,10 +93,11 @@ function fastifySwagger (fastify, opts, done) {
     url: '/yaml',
     method: 'GET',
     schema: { hide: true },
-    handler: function (req, reply) {
+    handler: async function (req, reply) {
+      const spec = await fastify.swagger({ yaml: true })
       reply
         .type('application/x-yaml')
-        .send(fastify.swagger({ yaml: true }))
+        .send(spec)
     }
   })
 

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -74,7 +74,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       if (schema instanceof Promise) {
         routePromises.push(
           schema
-            .then(schema => processRouteSchema(route, schema))
+            .then(schema => processRouteSchema(route, schema, defOpts, openapiObject, ref))
             .then(({ url, openapiRoute }) => {
               if (url && openapiRoute) {
                 openapiObject.paths[url] = openapiRoute

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -4,6 +4,39 @@ const yaml = require('js-yaml')
 const { shouldRouteHide } = require('../../util/common')
 const { prepareDefaultOptions, prepareOpenapiObject, prepareOpenapiMethod, normalizeUrl } = require('./utils')
 
+function processRouteSchema (route, schema, defOpts, openapiObject, ref) {
+  const shouldRouteHideOpts = {
+    hiddenTag: defOpts.hiddenTag,
+    hideUntagged: defOpts.hideUntagged
+  }
+
+  if (shouldRouteHide(schema, shouldRouteHideOpts)) return { url: null, openapiRoute: null }
+
+  const url = normalizeUrl(route.url, defOpts.servers, defOpts.stripBasePath)
+
+  const openapiRoute = Object.assign({}, openapiObject.paths[url])
+
+  const openapiMethod = prepareOpenapiMethod(schema, ref, openapiObject)
+
+  if (route.links) {
+    for (const statusCode of Object.keys(route.links)) {
+      if (!openapiMethod.responses[statusCode]) {
+        throw new Error(`missing status code ${statusCode} in route ${route.path}`)
+      }
+      openapiMethod.responses[statusCode].links = route.links[statusCode]
+    }
+  }
+
+  // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
+  const methods = typeof route.method === 'string' ? [route.method] : route.method
+
+  for (const method of methods) {
+    openapiRoute[method.toLowerCase()] = openapiMethod
+  }
+
+  return { url, openapiRoute }
+}
+
 module.exports = function (opts, cache, routes, Ref, done) {
   let ref
 
@@ -31,49 +64,47 @@ module.exports = function (opts, cache, routes, Ref, done) {
     Object.values(openapiObject.components.schemas)
       .forEach((_) => { delete _.$id })
 
+    const routePromises = []
+
     for (const route of routes) {
       const schema = defOpts.transform
         ? defOpts.transform(route.schema)
         : route.schema
 
-      const shouldRouteHideOpts = {
-        hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+      if (schema instanceof Promise) {
+        routePromises.push(
+          schema
+            .then(schema => processRouteSchema(route, schema))
+            .then(({ url, openapiRoute }) => {
+              if (url && openapiRoute) {
+                openapiObject.paths[url] = openapiRoute
+              }
+            }))
+
+        continue
       }
 
-      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
+      const { url, openapiRoute } = processRouteSchema(route, schema, defOpts, openapiObject, ref)
 
-      const url = normalizeUrl(route.url, defOpts.servers, defOpts.stripBasePath)
-
-      const openapiRoute = Object.assign({}, openapiObject.paths[url])
-
-      const openapiMethod = prepareOpenapiMethod(schema, ref, openapiObject)
-
-      if (route.links) {
-        for (const statusCode of Object.keys(route.links)) {
-          if (!openapiMethod.responses[statusCode]) {
-            throw new Error(`missing status code ${statusCode} in route ${route.path}`)
-          }
-          openapiMethod.responses[statusCode].links = route.links[statusCode]
-        }
+      if (url && openapiRoute) {
+        openapiObject.paths[url] = openapiRoute
       }
-
-      // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
-      const methods = typeof route.method === 'string' ? [route.method] : route.method
-
-      for (const method of methods) {
-        openapiRoute[method.toLowerCase()] = openapiMethod
-      }
-
-      openapiObject.paths[url] = openapiRoute
     }
 
-    if (opts && opts.yaml) {
-      cache.string = yaml.dump(openapiObject, { skipInvalid: true })
-      return cache.string
+    function finish () {
+      if (opts && opts.yaml) {
+        cache.string = yaml.dump(openapiObject, { skipInvalid: true })
+        return cache.string
+      }
+
+      cache.object = openapiObject
+      return cache.object
     }
 
-    cache.object = openapiObject
-    return cache.object
+    if (routePromises.length) {
+      return Promise.all(routePromises).then(finish)
+    }
+
+    return finish()
   }
 }

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -4,6 +4,34 @@ const yaml = require('js-yaml')
 const { shouldRouteHide } = require('../../util/common')
 const { prepareDefaultOptions, prepareSwaggerObject, prepareSwaggerMethod, normalizeUrl } = require('./utils')
 
+function processRouteSchema (route, schema, defOpts, swaggerObject, ref) {
+  const shouldRouteHideOpts = {
+    hiddenTag: defOpts.hiddenTag,
+    hideUntagged: defOpts.hideUntagged
+  }
+
+  if (shouldRouteHide(schema, shouldRouteHideOpts)) return { url: null, swaggerRoute: null }
+
+  const url = normalizeUrl(route.url, defOpts.basePath, defOpts.stripBasePath)
+
+  const swaggerRoute = Object.assign({}, swaggerObject.paths[url])
+
+  const swaggerMethod = prepareSwaggerMethod(schema, ref, swaggerObject)
+
+  if (route.links) {
+    throw new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see fastify-swagger readme)')
+  }
+
+  // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
+  const methods = typeof route.method === 'string' ? [route.method] : route.method
+
+  for (const method of methods) {
+    swaggerRoute[method.toLowerCase()] = swaggerMethod
+  }
+
+  return { url, swaggerRoute }
+}
+
 module.exports = function (opts, cache, routes, Ref, done) {
   let ref
 
@@ -31,44 +59,48 @@ module.exports = function (opts, cache, routes, Ref, done) {
       .forEach(_ => { delete _.$id })
 
     swaggerObject.paths = {}
+
+    const routePromises = []
+
     for (const route of routes) {
       const schema = defOpts.transform
         ? defOpts.transform(route.schema)
         : route.schema
 
-      const shouldRouteHideOpts = {
-        hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+      if (schema instanceof Promise) {
+        routePromises.push(
+          schema
+            .then(schema => processRouteSchema(route, schema))
+            .then(({ url, swaggerRoute }) => {
+              if (url && swaggerRoute) {
+                swaggerObject.paths[url] = swaggerRoute
+              }
+            }))
+
+        continue
       }
 
-      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
+      const { url, swaggerRoute } = processRouteSchema(route, schema, defOpts, swaggerObject, ref)
 
-      const url = normalizeUrl(route.url, defOpts.basePath, defOpts.stripBasePath)
-
-      const swaggerRoute = Object.assign({}, swaggerObject.paths[url])
-
-      const swaggerMethod = prepareSwaggerMethod(schema, ref, swaggerObject)
-
-      if (route.links) {
-        throw new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see fastify-swagger readme)')
+      if (url && swaggerRoute) {
+        swaggerObject.paths[url] = swaggerRoute
       }
-
-      // route.method should be either a String, like 'POST', or an Array of Strings, like ['POST','PUT','PATCH']
-      const methods = typeof route.method === 'string' ? [route.method] : route.method
-
-      for (const method of methods) {
-        swaggerRoute[method.toLowerCase()] = swaggerMethod
-      }
-
-      swaggerObject.paths[url] = swaggerRoute
     }
 
-    if (opts && opts.yaml) {
-      cache.string = yaml.dump(swaggerObject, { skipInvalid: true })
-      return cache.string
+    function finish () {
+      if (opts && opts.yaml) {
+        cache.string = yaml.dump(swaggerObject, { skipInvalid: true })
+        return cache.string
+      }
+
+      cache.object = swaggerObject
+      return cache.object
     }
 
-    cache.object = swaggerObject
-    return cache.object
+    if (routePromises.length) {
+      return Promise.all(routePromises).then(finish)
+    }
+
+    return finish()
   }
 }

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -70,7 +70,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       if (schema instanceof Promise) {
         routePromises.push(
           schema
-            .then(schema => processRouteSchema(route, schema))
+            .then(schema => processRouteSchema(route, schema, defOpts, swaggerObject, ref))
             .then(({ url, swaggerRoute }) => {
               if (url && swaggerRoute) {
                 swaggerObject.paths[url] = swaggerRoute

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,9 +11,11 @@ const params = Joi
   .keys({
     property: Joi.string().required()
   })
+
 const opts = {
   schema: { params }
 }
+
 const convertible = ['params', 'body', 'querystring']
 const valid = {
   transform: schema => Object.keys(schema).reduce((transformed, key) => {
@@ -24,9 +26,11 @@ const valid = {
   },
   {})
 }
+
 const invalid = {
   transform: 'wrong type'
 }
+
 test('transform should fail with a value other than Function', t => {
   t.plan(2)
   const fastify = Fastify()
@@ -41,6 +45,7 @@ test('transform should fail with a value other than Function', t => {
     t.throws(fastify.swagger)
   })
 })
+
 test('transform should work with a Function', t => {
   t.plan(2)
   const fastify = Fastify()
@@ -53,5 +58,79 @@ test('transform should work with a Function', t => {
   fastify.ready(err => {
     t.error(err)
     t.doesNotThrow(fastify.swagger)
+  })
+})
+
+test('transform should work with an AsyncFunction for openapi', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    openapi: {},
+    transform: async schema => valid.transform(schema)
+  })
+
+  fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
+  fastify.get('/example', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    t.resolves(fastify.swagger)
+  })
+})
+
+test('openapi should skip untagged routes', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    openapi: {},
+    transform: async schema => valid.transform(schema),
+    hideUntagged: true
+  })
+
+  fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
+  fastify.get('/example', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    t.resolves(fastify.swagger)
+  })
+})
+
+test('transform should work with an AsyncFunction for swagger', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    swagger: {},
+    transform: async schema => valid.transform(schema)
+  })
+
+  fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
+  fastify.get('/example', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    t.resolves(fastify.swagger)
+  })
+})
+
+test('async transform for swagger should skip untagged routes', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    swagger: {},
+    transform: async schema => valid.transform(schema),
+    hideUntagged: true
+  })
+
+  fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
+  fastify.get('/example', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+    t.resolves(fastify.swagger)
   })
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -61,8 +61,8 @@ test('transform should work with a Function', t => {
   })
 })
 
-test('transform should work with an AsyncFunction for openapi', t => {
-  t.plan(2)
+test('transform should work with an AsyncFunction for openapi', async t => {
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, {
@@ -73,13 +73,22 @@ test('transform should work with an AsyncFunction for openapi', t => {
   fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.resolves(fastify.swagger)
-  })
+  await fastify.ready()
+  const openapiObject = await fastify.swagger()
+
+  t.ok(openapiObject.paths)
+  t.ok(openapiObject.paths['/example'])
+  t.same(openapiObject.paths['/example'].get.parameters, [
+    {
+      in: 'path',
+      name: 'property',
+      required: true,
+      schema: { type: 'string' }
+    }
+  ])
 })
 
-test('openapi should skip untagged routes', t => {
+test('openapi should skip untagged routes', async t => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -92,14 +101,15 @@ test('openapi should skip untagged routes', t => {
   fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.resolves(fastify.swagger)
-  })
+  await fastify.ready()
+  const openapiObject = await fastify.swagger()
+
+  t.ok(openapiObject.paths)
+  t.same(openapiObject.paths, {})
 })
 
-test('transform should work with an AsyncFunction for swagger', t => {
-  t.plan(2)
+test('transform should work with an AsyncFunction for swagger', async t => {
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, {
@@ -110,13 +120,22 @@ test('transform should work with an AsyncFunction for swagger', t => {
   fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.resolves(fastify.swagger)
-  })
+  await fastify.ready()
+  const swaggerObject = await fastify.swagger()
+
+  t.ok(swaggerObject.paths)
+  t.ok(swaggerObject.paths['/example'])
+  t.same(swaggerObject.paths['/example'].get.parameters, [
+    {
+      in: 'path',
+      name: 'property',
+      required: true,
+      type: 'string'
+    }
+  ])
 })
 
-test('async transform for swagger should skip untagged routes', t => {
+test('async transform for swagger should skip untagged routes', async t => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -129,8 +148,9 @@ test('async transform for swagger should skip untagged routes', t => {
   fastify.setValidatorCompiler(({ schema }) => Joi.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.resolves(fastify.swagger)
-  })
+  await fastify.ready()
+  const swaggerObject = await fastify.swagger()
+
+  t.ok(swaggerObject.paths)
+  t.same(swaggerObject.paths, {})
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -74,7 +74,7 @@ test('transform should work with an AsyncFunction for openapi', async t => {
   fastify.get('/example', opts, () => {})
 
   await fastify.ready()
-  const openapiObject = await fastify.swagger()
+  const openapiObject = fastify.swagger()
 
   t.ok(openapiObject.paths)
   t.ok(openapiObject.paths['/example'])
@@ -102,7 +102,7 @@ test('openapi should skip untagged routes', async t => {
   fastify.get('/example', opts, () => {})
 
   await fastify.ready()
-  const openapiObject = await fastify.swagger()
+  const openapiObject = fastify.swagger()
 
   t.ok(openapiObject.paths)
   t.same(openapiObject.paths, {})
@@ -121,7 +121,7 @@ test('transform should work with an AsyncFunction for swagger', async t => {
   fastify.get('/example', opts, () => {})
 
   await fastify.ready()
-  const swaggerObject = await fastify.swagger()
+  const swaggerObject = fastify.swagger()
 
   t.ok(swaggerObject.paths)
   t.ok(swaggerObject.paths['/example'])
@@ -149,7 +149,7 @@ test('async transform for swagger should skip untagged routes', async t => {
   fastify.get('/example', opts, () => {})
 
   await fastify.ready()
-  const swaggerObject = await fastify.swagger()
+  const swaggerObject = fastify.swagger()
 
   t.ok(swaggerObject.paths)
   t.same(swaggerObject.paths, {})

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -7,6 +7,7 @@ const app = fastify();
 app.register(fastifySwagger);
 app.register(fastifySwagger, {});
 app.register(fastifySwagger, { transform: (schema : any) => schema });
+app.register(fastifySwagger, { transform: async (schema : any) => schema });
 app.register(fastifySwagger, {
   mode: 'static',
   specification: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Add support for providing an asynchronous function to `transform` in options, to allow using some libraries that need to be awaited.  When a Promise-returning/`async` function is provided to `transform`, `fastify.swagger()` returns a Promise instead of just the schema object, so this doesn't bring about a breaking change, as discussed in #446.

Closes #446.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
