### PR TITLE
feat: Extract the type of initOAuth and uiConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,44 +53,47 @@ export interface FastifySwaggerOptions {
   /**
    * Swagger UI Config
    */
-  uiConfig?: Partial<{
-    deepLinking: boolean
-    displayOperationId: boolean
-    defaultModelsExpandDepth: number
-    defaultModelExpandDepth: number
-    defaultModelRendering: string
-    displayRequestDuration: boolean
-    docExpansion: string
-    filter: boolean | string
-    maxDisplayedTags: number
-    showExtensions: boolean
-    showCommonExtensions: boolean
-    useUnsafeMarkdown: boolean
-    syntaxHighlight: {
-      activate?: boolean
-      theme?: string
-    } | false
-    tryItOutEnabled: boolean
-    validatorUrl: string | null
-  }>
-  
-  initOAuth?: Partial<{
-    clientId: string,
-    clientSecret: string,
-    realm: string,
-    appName: string,
-    scopeSeparator: string,
-    scopes: string | string[],
-    additionalQueryStringParams: { [key: string]: any },
-    useBasicAuthenticationWithAccessCodeGrant: boolean,
-    usePkceWithAuthorizationCodeGrant: boolean
-  }>
+  uiConfig?: FastifySwaggerUiConfigOptions
+  initOAuth?: FastifySwaggerInitOAuthOptions
   /**
    * CSP Config
    */
   staticCSP?: boolean | string | Record<string, string | string[]>
   transformStaticCSP?: (header: string) => string
 }
+
+export type FastifySwaggerUiConfigOptions = Partial<{
+  deepLinking: boolean
+  displayOperationId: boolean
+  defaultModelsExpandDepth: number
+  defaultModelExpandDepth: number
+  defaultModelRendering: string
+  displayRequestDuration: boolean
+  docExpansion: string
+  filter: boolean | string
+  maxDisplayedTags: number
+  showExtensions: boolean
+  showCommonExtensions: boolean
+  useUnsafeMarkdown: boolean
+  syntaxHighlight: {
+    activate?: boolean
+    theme?: string
+  } | false
+  tryItOutEnabled: boolean
+  validatorUrl: string | null
+}>
+
+export type FastifySwaggerInitOAuthOptions = Partial<{
+  clientId: string,
+  clientSecret: string,
+  realm: string,
+  appName: string,
+  scopeSeparator: string,
+  scopes: string | string[],
+  additionalQueryStringParams: { [key: string]: any },
+  useBasicAuthenticationWithAccessCodeGrant: boolean,
+  usePkceWithAuthorizationCodeGrant: boolean
+}>
 
 export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
   mode?: 'dynamic';

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,8 +1,17 @@
 import fastify from 'fastify';
-import fastifySwagger, { SwaggerOptions } from '../..';
+import fastifySwagger, { SwaggerOptions, FastifySwaggerInitOAuthOptions, FastifySwaggerUiConfigOptions } from '../..';
 import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 
 const app = fastify();
+const uiConfig: FastifySwaggerUiConfigOptions = {
+  deepLinking: true,
+  defaultModelsExpandDepth: -1,
+  defaultModelExpandDepth: 1,
+  validatorUrl: null,
+};
+const initOAuth: FastifySwaggerInitOAuthOptions = {
+  scopes: ['openid', 'profile', 'email', 'offline_access'],
+};
 
 app.register(fastifySwagger);
 app.register(fastifySwagger, {});
@@ -118,21 +127,14 @@ app
         },
       },
     },
-    initOAuth: {
-      scopes: ['openid', 'profile', 'email', 'offline_access'],
-    },
+    initOAuth
   })
   .ready((err) => {
     app.swagger();
   });
 
 app.register(fastifySwagger, {
-  uiConfig: {
-    deepLinking: true,
-    defaultModelsExpandDepth: -1,
-    defaultModelExpandDepth: 1,
-    validatorUrl: null
-  }
+  uiConfig
 })
 .ready((err) => {
   app.swagger();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Why:

I wanna add a type for uiConfig on the project [@nestjs/swagger](https://github.com/nestjs/swagger/blob/5bf65b9d16bc5d9dfd6119b3e87af85439830da0/lib/interfaces/swagger-custom-options.interface.ts#L16) but upstream `fastify-swagger` doesn't export that.