### PR TITLE
feat: customize def-0 model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ fastify.register(require('fastify-swagger'), {
 When this plugin is configured as `dynamic` mode, it will resolve all `$ref`s in your application's schemas.
 This process will create an new in-line schema that is going to reference itself.
 
-This logic stap it is done to make sure that the generated documentation is valid, otherwise the Swagger UI will try to fetch the schemas from the server or the network and fail.
+This logic step is done to make sure that the generated documentation is valid, otherwise the Swagger UI will try to fetch the schemas from the server or the network and fail.
 
 By default, this option will resolve all `$ref`s renaming them to `def-${counter}`, but your view models keep the original `$id` naming thanks to the [`title` parameter](https://swagger.io/docs/specification/2-0/basic-structure/#metadata).
 
@@ -274,7 +274,7 @@ fastify.register(require('fastify-swagger'), {
   ...
   refResolver: {
     buildLocalReference (json, baseUri, fragment, i) {
-      return `my-fragment-${i}`
+      return json.$id || `my-fragment-${i}`
     }
   }
 }
@@ -663,6 +663,10 @@ You can integration this plugin with ```fastify-helmet``` with some little work.
   }
 })
 ```
+
+<a name="usage"></a>
+## `$id` and `$ref` usage
+
 
 ## Development
 In order to start development run:

--- a/examples/dynamic-swagger.js
+++ b/examples/dynamic-swagger.js
@@ -25,31 +25,37 @@ fastify.register(require('../index'), {
   exposeRoute: true
 })
 
+fastify.addSchema({
+  $id: 'user',
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+      description: 'user id'
+    }
+  }
+})
+
+fastify.addSchema({
+  $id: 'some',
+  type: 'object',
+  properties: {
+    some: { type: 'string' }
+  }
+})
+
 fastify.put('/some-route/:id', {
   schema: {
     description: 'post some data',
     tags: ['user', 'code'],
     summary: 'qwerty',
     security: [{ apiKey: [] }],
-    params: {
-      type: 'object',
-      properties: {
-        id: {
-          type: 'string',
-          description: 'user id'
-        }
-      }
-    },
+    params: { $ref: 'user#' },
     body: {
       type: 'object',
       properties: {
         hello: { type: 'string' },
-        obj: {
-          type: 'object',
-          properties: {
-            some: { type: 'string' }
-          }
-        }
+        obj: { $ref: 'some#' }
       }
     },
     response: {
@@ -69,25 +75,12 @@ fastify.post('/some-route/:id', {
     description: 'post some data',
     summary: 'qwerty',
     security: [{ apiKey: [] }],
-    params: {
-      type: 'object',
-      properties: {
-        id: {
-          type: 'string',
-          description: 'user id'
-        }
-      }
-    },
+    params: { $ref: 'user#' },
     body: {
       type: 'object',
       properties: {
         hello: { type: 'string' },
-        obj: {
-          type: 'object',
-          properties: {
-            some: { type: 'string' }
-          }
-        }
+        obj: { $ref: 'some#' }
       }
     },
     response: {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -3,8 +3,6 @@
 const { addHook, resolveSwaggerFunction } = require('../util/common')
 
 module.exports = function (fastify, opts, done) {
-  const { routes, Ref } = addHook(fastify)
-
   opts = Object.assign({}, {
     exposeRoute: false,
     hiddenTag: 'X-HIDDEN',
@@ -12,8 +10,18 @@ module.exports = function (fastify, opts, done) {
     stripBasePath: true,
     openapi: null,
     swagger: {},
-    transform: null
+    transform: null,
+    refResolver: {
+      buildLocalReference (json, baseUri, fragment, i) {
+        if (!json.title && json.$id) {
+          json.title = json.$id
+        }
+        return `def-${i}`
+      }
+    }
   }, opts)
+
+  const { routes, Ref } = addHook(fastify, opts)
 
   if (opts.exposeRoute === true) {
     const prefix = opts.routePrefix || '/documentation'

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -6,7 +6,7 @@ const Ref = require('json-schema-resolver')
 const { rawRequired } = require('../symbols')
 const { xConsume } = require('../constants')
 
-function addHook (fastify) {
+function addHook (fastify, pluginOptions) {
   const routes = []
   const sharedSchemasMap = new Map()
 
@@ -35,8 +35,11 @@ function addHook (fastify) {
     routes,
     Ref () {
       const externalSchemas = Array.from(sharedSchemasMap.values())
-      // TODO: hardcoded applicationUri is not a ideal solution
-      return Ref({ clone: true, applicationUri: 'todo.com', externalSchemas })
+      return Ref(Object.assign(
+        { applicationUri: 'todo.com' },
+        pluginOptions.refResolver,
+        { clone: true, externalSchemas })
+      )
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^4.0.0",
     "js-yaml": "^4.0.0",
-    "json-schema-resolver": "github:Eomm/json-schema-resolver#ref-to-def",
+    "json-schema-resolver": "^1.3.0",
     "openapi-types": "^9.1.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^4.0.0",
     "js-yaml": "^4.0.0",
-    "json-schema-resolver": "^1.2.0",
+    "json-schema-resolver": "github:Eomm/json-schema-resolver#ref-to-def",
     "openapi-types": "^9.1.0"
   },
   "standard": {

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -308,5 +308,25 @@ test('support global schema reference', async t => {
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
-  t.same(api.components.schemas['def-0'], schema)
+  t.match(api.components.schemas['def-0'], schema)
+})
+
+test('support global schema reference with title', async t => {
+  const schema = {
+    title: 'schema view title',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    },
+    required: ['hello']
+  }
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
+  fastify.addSchema({ ...schema, $id: 'requiredUniqueSchema' })
+  fastify.get('/', { schema: { query: { $ref: 'requiredUniqueSchema' } } }, () => {})
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+  t.match(api.components.schemas['def-0'], schema)
 })


### PR DESCRIPTION
This PR:

- fixes the **swagger UI layout** to show the schema's `$id` as model name (see screenshot at the bottom). Under the hood, the `def-0` renaming is still in place.
- adds documentation to describe what is happening under the hood.
- adds the option to customize the `$ref`'s link into the inline schema. This gives to the user the chance to do what he/she wants and remove totally the `def-0` logic.

I think this (too simple?) solution solves the case.
Feel free to give feedback about this PR

### Why this change

To avoid a major bump, this PR fixes the view issue without breaking the `def-0` logic that has been developed to protect users actually 😄 

Let me explain.

This JSON Schema has a relative URI `$id`. 

```
fastify.addSchema({
  $id: 'user',
  type: 'object',
  definitions: {
    id: {
      type: 'string',
      description: 'user id'
    }
  }
})
```

This is wrong from the [DRAFT 07 specification](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01#section-8.2.1):

>    The root schema of a JSON Schema document SHOULD contain an "$id"
>   keyword with an absolute-URI [RFC3986] (containing a scheme, but no
>   fragment), or this absolute URI but with an empty fragment.

Moreover, referencing the `user` schema with the `$ref: 'user#/definitions/id'` is wrong from the specification point of view: the reference is relative and it should be resolved using the local schema's root URI, not the external one (the `$id: 'user'` one to be clear).

The `fastify-swagger` knows that the `$id` field is used as a simple key/value pair actually.
For this reason, it ignores the user's `$id`*** and deference the schema to a `def-0`: to be sure to avoid conflicts to let the `swagger-ui` module resolve correctly the references. Otherwise, you may have different output based on the `$id`s the developer set.
The specification, cover a lot more use cases than I saw in the GitHub issues actually.

The last example, setting an absolute root URI tells to the `swagger-ui` module to fetch the schema from the link!

```
fastify.addSchema({
  $id: 'http://example.com/user.json',
  ...
```

This snippet causes the swagger-ui module to make an HTTP request to `http://example.com/user.json`!

Now, forcing `fastify-swagger` to use the `$id` can break the configuration of those devs that use the standard strictly.
Using the `$id` in place of `def-0` is correct only if the developer knows that there is no conflicts or nested schema's declarations. 
With this PR, the user may replace the `buildLocalReference` option to accomplish this. But this behaviour leads to a "convention over configuration" strategy.


Before|After|
|---|---|
![image](https://user-images.githubusercontent.com/11404065/131364651-4aea87d3-e851-43a5-bd42-9e904ad5323f.png) | ![image](https://user-images.githubusercontent.com/11404065/131364817-601cb2e0-5a07-4987-97a5-bf8cd7ea50c0.png)


Fixes https://github.com/fastify/fastify-swagger/issues/337
Fixes https://github.com/fastify/fastify-swagger/issues/286
Fixes https://github.com/fastify/fastify-swagger/issues/225
Should help https://github.com/fastify/fastify-swagger/pull/432


\*** when I say that this module "ignores" the `$id`s I mean that we know that all the `$ref` can be resolved locally, accessing the data added to the fastify schema via the `addSchema` method. If the user set an absolute URI as `$id`, fastify will never look up an external link.
