### PR TITLE
chore: add support for "default" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ fastify.put('/some-route/:id', {
         properties: {
           hello: { type: 'string' }
         }
+      },
+      default: {
+        description: 'Default response',
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
       }
     },
     security: [
@@ -377,7 +384,7 @@ Example:
 {
   response: {
     '2xx': {
-      description: '2xx'
+      description: '2xx',
       type: 'object'
     }
   }
@@ -388,7 +395,7 @@ Example:
   response: {
     200: {
       schema: {
-        description: '2xx'
+        description: '2xx',
         type: 'object'
       }
     }

--- a/examples/dynamic-openapi.js
+++ b/examples/dynamic-openapi.js
@@ -60,6 +60,13 @@ fastify.put('/some-route/:id', {
         properties: {
           hello: { type: 'string' }
         }
+      },
+      default: {
+        description: 'Default response',
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
       }
     }
   }

--- a/examples/dynamic-swagger.js
+++ b/examples/dynamic-swagger.js
@@ -65,6 +65,13 @@ fastify.put('/some-route/:id', {
         properties: {
           hello: { type: 'string' }
         }
+      },
+      default: {
+        description: 'Default response',
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
       }
     }
   }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -226,8 +226,13 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
     const rawJsonSchema = fastifyResponseJson[statusCode]
     const resolved = transformDefsToComponents(ref.resolve(rawJsonSchema))
 
-    // 2xx require to be all upper-case
-    statusCode = statusCode.toUpperCase()
+    /**
+     * 2xx require to be all upper-case
+     * converts statusCode to upper case only when it is not "default"
+     */
+    if (statusCode !== 'default') {
+      statusCode = statusCode.toUpperCase()
+    }
 
     const response = {
       description: resolved[xResponseDescription] || rawJsonSchema.description || 'Default Response'

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -200,7 +200,11 @@ function resolveResponse (fastifyResponseJson, ref) {
     if (statusCode.toUpperCase().includes('XX') && statusCodes.includes(deXXStatusCode)) {
       return
     }
-    statusCode = deXXStatusCode
+
+    // converts statusCode to upper case only when it is not "default"
+    if (statusCode !== 'default') {
+      statusCode = deXXStatusCode
+    }
 
     const response = {
       description: rawJsonSchema[xResponseDescription] || rawJsonSchema.description || 'Default Response'

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -330,3 +330,62 @@ test('support global schema reference with title', async t => {
   const api = await Swagger.validate(swaggerObject)
   t.match(api.components.schemas['def-0'], schema)
 })
+
+test('support "default" parameter', async t => {
+  const opt = {
+    schema: {
+      response: {
+        200: {
+          description: 'Expected Response',
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          }
+        },
+        default: {
+          description: 'Default Response',
+          type: 'object',
+          properties: {
+            bar: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    openapi: true,
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+
+  t.same(definedPath.responses.default, {
+    description: 'Default Response',
+    content: {
+      'application/json': {
+        schema: {
+          description: 'Default Response',
+          type: 'object',
+          properties: {
+            bar: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  })
+})

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -334,3 +334,57 @@ test('response: description and x-response-description', async () => {
     t.equal(responseObject.schema.responseDescription, undefined)
   })
 })
+
+test('support "default" parameter', async t => {
+  const opt = {
+    schema: {
+      response: {
+        200: {
+          description: 'Expected Response',
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          }
+        },
+        default: {
+          description: 'Default Response',
+          type: 'object',
+          properties: {
+            bar: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.register(fastifySwagger, {
+    routePrefix: '/docs',
+    exposeRoute: true
+  })
+  fastify.get('/', opt, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+
+  t.same(definedPath.responses.default, {
+    description: 'Default Response',
+    schema: {
+      description: 'Default Response',
+      type: 'object',
+      properties: {
+        bar: {
+          type: 'string'
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fastify-swagger/issues/441

OpenAPI 3 generated schema
<details>
<summary>Click to expand</summary>

```yaml
openapi: 3.0.3
info:
  version: 4.10.0
  title: fastify-swagger
components:
  schemas: {}
paths:
  /:
    get:
      responses:
        '200':
          description: Expected Response
          content:
            application/json:
              schema:
                description: Expected Response
                type: object
                properties:
                  foo:
                    type: string
        default:
          description: Default Response
          content:
            application/json:
              schema:
                description: Default Response
                type: object
                properties:
                  bar:
                    type: string
```
</details>

Swagger generated schema
<details>
<summary>Click to expand</summary>

```yaml
swagger: '2.0'
info:
  version: 4.10.0
  title: fastify-swagger
definitions: {}
paths:
  /:
    get:
      responses:
        '200':
          description: Expected Response
          schema:
            description: Expected Response
            type: object
            properties:
              foo:
                type: string
        default:
          description: Default Response
          schema:
            description: Default Response
            type: object
            properties:
              bar:
                type: string
```
</details>