### PR TITLE
fix: generate correct openapi with response schema containing ref

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -88,6 +88,8 @@ function transformDefsToComponents (jsonSchema) {
       } else if (key === 'examples' && Array.isArray(jsonSchema[key]) && (jsonSchema[key].length === 1)) {
         jsonSchema.example = jsonSchema[key][0]
         delete jsonSchema[key]
+      } else if (key === '$id') {
+        delete jsonSchema[key]
       } else {
         jsonSchema[key] = transformDefsToComponents(jsonSchema[key])
       }

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -84,3 +84,22 @@ test('support nested $ref schema : complex case', async (t) => {
 
   await Swagger.validate(openapiObject)
 })
+
+test('support $ref schema', async (t) => {
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+  fastify.register(function (instance, _, done) {
+    instance.addSchema({ $id: 'order', type: 'string', enum: ['foo'] })
+    instance.post('/', { schema: { response: { 200: { type: 'object', properties: { order: { $ref: 'order' } } } } } }, () => {})
+
+    done()
+  })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
+
+  await Swagger.validate(openapiObject)
+})

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -85,7 +85,7 @@ test('support nested $ref schema : complex case', async (t) => {
   await Swagger.validate(openapiObject)
 })
 
-test('support $ref schema', async (t) => {
+test('support $ref in response schema', async (t) => {
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, openapiOption)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

When a response schema is created with a `$ref` not at first level (as in the added test), the openapi spec is not valid because of the `$id` key from the added schema.

Here the output of the test before (not a valid oas)

```yml
openapi: 3.0.3
info:
  version: 4.12.1
  title: fastify-swagger
components:
  schemas:
    order:
      type: string
      enum:
        - foo
paths:
  /:
    post:
      responses:
        '200':
          description: Default Response
          content:
            application/json:
              schema:
                type: object
                properties:
                  order:
                    $id: order
                    type: string
                    enum:
                      - foo
```

and after the change (this is valid because order does not contains the `$id` key):

```yml
openapi: 3.0.3
info:
  version: 4.12.1
  title: fastify-swagger
components:
  schemas:
    order:
      type: string
      enum:
        - foo
paths:
  /:
    post:
      responses:
        '200':
          description: Default Response
          content:
            application/json:
              schema:
                type: object
                properties:
                  order:
                    type: string
                    enum:
                      - foo
```


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
