### PR TITLE
Allow openapi version config

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -6,6 +6,7 @@ const { rawRequired } = require('../../symbols')
 
 function prepareDefaultOptions (opts) {
   const openapi = opts.openapi
+  const openapiVersion = openapi.openapi || null
   const info = openapi.info || null
   const servers = openapi.servers || null
   const components = openapi.components || null
@@ -25,6 +26,7 @@ function prepareDefaultOptions (opts) {
   }
 
   return {
+    openapi: openapiVersion,
     info,
     servers,
     components,
@@ -51,6 +53,7 @@ function prepareOpenapiObject (opts) {
     paths: {}
   }
 
+  if (opts.openapi) openapiObject.openapi = opts.openapi
   if (opts.info) openapiObject.info = opts.info
   if (opts.servers) openapiObject.servers = opts.servers
   if (opts.components) openapiObject.components = Object.assign({}, opts.components, { schemas: Object.assign({}, opts.components.schemas) })

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -22,6 +22,20 @@ test('openapi should have default version', t => {
   })
 })
 
+test('openapi openapi property', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, { openapi: { openapi: '3.1.0' } })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.equal(openapiObject.openapi, '3.1.0')
+  })
+})
+
 test('openapi should have default info properties', t => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
Openapi version is set to 3.0.3 as default no allowing to be modified by options object.
This PR allow override the openapi version if 'openapi' attribute is defined in options object.