### PR TITLE
Ignore schema items when used and in security definitions 

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -112,7 +112,7 @@ function convertExamplesArrayToObject (examples) {
 
 // For supported keys read:
 // https://swagger.io/docs/specification/describing-parameters/
-function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
+function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, securityIgnores = []) {
   const obj = transformDefsToComponents(resolveLocalRef(jsonSchema, externalSchemas))
   let toOpenapiProp
   switch (container) {
@@ -173,16 +173,18 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas) {
       break
   }
 
-  return Object.keys(obj).map((propKey) => {
-    const jsonSchema = toOpenapiProp(propKey, obj[propKey])
-    if (jsonSchema.schema) {
-      // it is needed as required in schema is invalid prop - delete only if needed
-      if (typeof jsonSchema.schema.required !== 'undefined') delete jsonSchema.schema.required
-      // it is needed as description in schema is invalid prop - delete only if needed
-      if (typeof jsonSchema.schema.description !== 'undefined') delete jsonSchema.schema.description
-    }
-    return jsonSchema
-  })
+  return Object.keys(obj)
+    .filter((propKey) => (!securityIgnores.includes(propKey)))
+    .map((propKey) => {
+      const jsonSchema = toOpenapiProp(propKey, obj[propKey])
+      if (jsonSchema.schema) {
+        // it is needed as required in schema is invalid prop - delete only if needed
+        if (typeof jsonSchema.schema.required !== 'undefined') delete jsonSchema.schema.required
+        // it is needed as description in schema is invalid prop - delete only if needed
+        if (typeof jsonSchema.schema.description !== 'undefined') delete jsonSchema.schema.description
+      }
+      return jsonSchema
+    })
 }
 
 function resolveBodyParams (content, schema, consumes, ref) {
@@ -199,7 +201,7 @@ function resolveBodyParams (content, schema, consumes, ref) {
   })
 }
 
-function resolveCommonParams (container, parameters, schema, ref, sharedSchemas) {
+function resolveCommonParams (container, parameters, schema, ref, sharedSchemas, securityIgnores) {
   const schemasPath = '#/components/schemas/'
   let resolved = transformDefsToComponents(ref.resolve(schema))
 
@@ -209,7 +211,7 @@ function resolveCommonParams (container, parameters, schema, ref, sharedSchemas)
     resolved = ref.definitions().definitions[parts[1]]
   }
 
-  const arr = plainJsonObjectToOpenapi3(container, resolved, sharedSchemas)
+  const arr = plainJsonObjectToOpenapi3(container, resolved, sharedSchemas, securityIgnores)
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }
 
@@ -288,6 +290,22 @@ function prepareOpenapiMethod (schema, ref, openapiObject) {
   const openapiMethod = {}
   const parameters = []
 
+  // Parse out the security prop keys to ignore
+  const securityIgnores = [
+    ...(openapiObject && openapiObject.security ? openapiObject.security : []),
+    ...(schema && schema.security ? schema.security : [])
+  ]
+    .reduce((acc, securitySchemeGroup) => {
+      Object.keys(securitySchemeGroup).forEach((securitySchemeLabel) => {
+        const { name, in: category } = openapiObject.components.securitySchemes[securitySchemeLabel]
+        if (!acc[category]) {
+          acc[category] = []
+        }
+        acc[category].push(name)
+      })
+      return acc
+    }, {})
+
   // All the data the user can give us, is via the schema object
   if (schema) {
     if (schema.operationId) openapiMethod.operationId = schema.operationId
@@ -295,16 +313,16 @@ function prepareOpenapiMethod (schema, ref, openapiObject) {
     if (schema.tags) openapiMethod.tags = schema.tags
     if (schema.description) openapiMethod.description = schema.description
     if (schema.externalDocs) openapiMethod.externalDocs = schema.externalDocs
-    if (schema.querystring) resolveCommonParams('query', parameters, schema.querystring, ref, openapiObject.definitions)
+    if (schema.querystring) resolveCommonParams('query', parameters, schema.querystring, ref, openapiObject.definitions, securityIgnores.query)
     if (schema.body) {
       openapiMethod.requestBody = { content: {} }
       resolveBodyParams(openapiMethod.requestBody.content, schema.body, schema.consumes, ref)
     }
     if (schema.params) resolveCommonParams('path', parameters, schema.params, ref, openapiObject.definitions)
-    if (schema.headers) resolveCommonParams('header', parameters, schema.headers, ref, openapiObject.definitions)
+    if (schema.headers) resolveCommonParams('header', parameters, schema.headers, ref, openapiObject.definitions, securityIgnores.header)
     // TODO: need to documentation, we treat it same as the querystring
     // fastify do not support cookies schema in first place
-    if (schema.cookies) resolveCommonParams('cookie', parameters, schema.cookies, ref, openapiObject.definitions)
+    if (schema.cookies) resolveCommonParams('cookie', parameters, schema.cookies, ref, openapiObject.definitions, securityIgnores.cookie)
     if (parameters.length > 0) openapiMethod.parameters = parameters
     if (schema.deprecated) openapiMethod.deprecated = schema.deprecated
     if (schema.security) openapiMethod.security = schema.security

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -95,7 +95,7 @@ function normalizeUrl (url, basePath, stripBasePath) {
 
 // For supported keys read:
 // https://swagger.io/docs/specification/2-0/describing-parameters/
-function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas) {
+function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas, securityIgnores = []) {
   const obj = resolveLocalRef(jsonSchema, externalSchemas)
   let toSwaggerProp
   switch (container) {
@@ -148,9 +148,11 @@ function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas) {
       break
   }
 
-  return Object.keys(obj).map((propKey) => {
-    return toSwaggerProp(propKey, obj[propKey])
-  })
+  return Object.keys(obj)
+    .filter((propKey) => (!securityIgnores.includes(propKey)))
+    .map((propKey) => {
+      return toSwaggerProp(propKey, obj[propKey])
+    })
 }
 
 function isConsumesFormOnly (schema) {
@@ -173,9 +175,9 @@ function resolveBodyParams (parameters, schema, ref) {
   })
 }
 
-function resolveCommonParams (container, parameters, schema, ref, sharedSchemas) {
+function resolveCommonParams (container, parameters, schema, ref, sharedSchemas, securityIgnores) {
   const resolved = ref.resolve(schema)
-  const arr = plainJsonObjectToSwagger2(container, resolved, sharedSchemas)
+  const arr = plainJsonObjectToSwagger2(container, resolved, sharedSchemas, securityIgnores)
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }
 
@@ -236,6 +238,22 @@ function prepareSwaggerMethod (schema, ref, swaggerObject) {
   const swaggerMethod = {}
   const parameters = []
 
+  // Parse out the security prop keys to ignore
+  const securityIgnores = [
+    ...(swaggerObject && swaggerObject.security ? swaggerObject.security : []),
+    ...(schema && schema.security ? schema.security : [])
+  ]
+    .reduce((acc, securitySchemeGroup) => {
+      Object.keys(securitySchemeGroup).forEach((securitySchemeLabel) => {
+        const { name, in: category } = swaggerObject.securityDefinitions[securitySchemeLabel]
+        if (!acc[category]) {
+          acc[category] = []
+        }
+        acc[category].push(name)
+      })
+      return acc
+    }, {})
+
   // All the data the user can give us, is via the schema object
   if (schema) {
     if (schema.operationId) swaggerMethod.operationId = schema.operationId
@@ -244,7 +262,7 @@ function prepareSwaggerMethod (schema, ref, swaggerObject) {
     if (schema.tags) swaggerMethod.tags = schema.tags
     if (schema.produces) swaggerMethod.produces = schema.produces
     if (schema.consumes) swaggerMethod.consumes = schema.consumes
-    if (schema.querystring) resolveCommonParams('query', parameters, schema.querystring, ref, swaggerObject.definitions)
+    if (schema.querystring) resolveCommonParams('query', parameters, schema.querystring, ref, swaggerObject.definitions, securityIgnores.query)
     if (schema.body) {
       const isConsumesAllFormOnly = isConsumesFormOnly(schema) || isConsumesFormOnly(swaggerObject)
       isConsumesAllFormOnly
@@ -252,7 +270,7 @@ function prepareSwaggerMethod (schema, ref, swaggerObject) {
         : resolveBodyParams(parameters, schema.body, ref)
     }
     if (schema.params) resolveCommonParams('path', parameters, schema.params, ref, swaggerObject.definitions)
-    if (schema.headers) resolveCommonParams('header', parameters, schema.headers, ref, swaggerObject.definitions)
+    if (schema.headers) resolveCommonParams('header', parameters, schema.headers, ref, swaggerObject.definitions, securityIgnores.header)
     if (parameters.length > 0) swaggerMethod.parameters = parameters
     if (schema.deprecated) swaggerMethod.deprecated = schema.deprecated
     if (schema.security) swaggerMethod.security = schema.security

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -696,3 +696,219 @@ test('links without status code', t => {
     t.throws(() => fastify.swagger(), new Error('missing status code 201 in route /user/:id'))
   })
 })
+
+test('security headers ignored when declared in security and securityScheme', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  fastify.get('/address1/:id', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.equal(typeof openapiObject, 'object')
+
+    Swagger.validate(openapiObject)
+      .then(function (api) {
+        t.pass('valid swagger object')
+        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+      })
+      .catch(function (err) {
+        t.error(err)
+      })
+  })
+})
+
+test('security querystrings ignored when declared in security and securityScheme', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    openapi: {
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: 'apiKey',
+            name: 'apiKey',
+            in: 'query'
+          }
+        }
+      },
+      security: [{
+        apiKey: []
+      }]
+    }
+  })
+
+  fastify.get('/address1/:id', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.equal(typeof openapiObject, 'object')
+
+    Swagger.validate(openapiObject)
+      .then(function (api) {
+        t.pass('valid swagger object')
+        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+      })
+      .catch(function (err) {
+        t.error(err)
+      })
+  })
+})
+
+test('security cookies ignored when declared in security and securityScheme', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, {
+    openapi: {
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: 'apiKey',
+            name: 'apiKey',
+            in: 'cookie'
+          }
+        }
+      },
+      security: [{
+        apiKey: []
+      }]
+    }
+  })
+
+  fastify.get('/address1/:id', {
+    schema: {
+      cookies: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      cookies: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          id: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.equal(typeof openapiObject, 'object')
+
+    Swagger.validate(openapiObject)
+      .then(function (api) {
+        t.pass('valid swagger object')
+        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+      })
+      .catch(function (err) {
+        t.error(err)
+      })
+  })
+})


### PR DESCRIPTION
Do not add/require cookies/query/headers on the openapi ui, if they match security definitions required by authorization feature.

In theory, this resolves #196 .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
