### PR TITLE
fix: format param url

### DIFF
--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -69,16 +69,80 @@ function shouldRouteHide (schema, opts) {
 // This function converts the url in a swagger compliant url string
 // => '/user/{id}'
 // custom verbs at the end of a url are okay => /user::watch but should be rendered as /user:watch in swagger
-function formatParamUrl (url) {
-  const regex = /(?<!:):([a-zA-Z0-9_]+)/g
-  let found = regex.exec(url)
-  while (found !== null) {
-    const [full, param] = found
-    url = url.replace(full, '{' + param + '}')
-    found = regex.exec(url)
+const COLON = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_'
+function formatParamUrl (str) {
+  let i, char
+  let state = 'skip'
+  let path = ''
+  let param = ''
+  let level = 0
+  // count for regex if no param exist
+  let regexp = 0
+  for (i = 0; i < str.length; i++) {
+    char = str[i]
+    switch (state) {
+      case 'colon': {
+        // we only accept a-zA-Z0-9_ in param
+        if (COLON.indexOf(char) !== -1) {
+          param += char
+        } else if (char === '(') {
+          state = 'regexp'
+          level++
+        } else {
+          // end
+          state = 'skip'
+          path += '{' + param + '}'
+          path += char
+          param = ''
+        }
+        break
+      }
+      case 'regexp': {
+        if (char === '(') {
+          level++
+        } else if (char === ')') {
+          level--
+        }
+        // we end if the level reach zero
+        if (level === 0) {
+          state = 'skip'
+          if (param === '') {
+            regexp++
+            param = 'regexp' + String(regexp)
+          }
+          path += '{' + param + '}'
+          param = ''
+        }
+        break
+      }
+      default: {
+        // we check if we need to change state
+        if (char === ':' && str[i + 1] === ':') {
+          // double colon -> single colon
+          path += char
+          // skip one more
+          i++
+        } else if (char === ':') {
+          // single colon -> state colon
+          state = 'colon'
+        } else if (char === '(') {
+          state = 'regexp'
+          level++
+        } else if (char === '*') {
+          // * -> wildcard
+          // should be exist once only
+          path += '{wildcard}'
+        } else {
+          path += char
+        }
+      }
+    }
   }
-
-  return url.replace(/::/g, ':')
+  // clean up
+  if (state === 'colon' && param !== '') {
+    path += '{' + param + '}'
+  }
+  return path
 }
 
 function resolveLocalRef (jsonSchema, externalSchemas) {

--- a/test/util.js
+++ b/test/util.js
@@ -12,9 +12,10 @@ const cases = [
   ['/example/:file(^\\d+).png', '/example/{file}.png'],
   ['/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', '/example/at/{hour}h{minute}m'],
   ['/example/at/(^\\d{2})h(^\\d{2})m', '/example/at/{regexp1}h{regexp2}m'],
+  ['/example/at/(^([0-9]{2})h$)-(^([0-9]{2})m$)','/example/at/{regexp1}-{regexp2}'],
   ['/name::verb', '/name:verb'],
   ['/api/v1/postalcode-jp/:code(^[0-9]{7}$)', '/api/v1/postalcode-jp/{code}'],
-  ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}']
+  ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}'],
 ]
 
 test('formatParamUrl', t => {

--- a/test/util.js
+++ b/test/util.js
@@ -12,10 +12,10 @@ const cases = [
   ['/example/:file(^\\d+).png', '/example/{file}.png'],
   ['/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', '/example/at/{hour}h{minute}m'],
   ['/example/at/(^\\d{2})h(^\\d{2})m', '/example/at/{regexp1}h{regexp2}m'],
-  ['/example/at/(^([0-9]{2})h$)-(^([0-9]{2})m$)','/example/at/{regexp1}-{regexp2}'],
+  ['/example/at/(^([0-9]{2})h$)-(^([0-9]{2})m$)', '/example/at/{regexp1}-{regexp2}'],
   ['/name::verb', '/name:verb'],
   ['/api/v1/postalcode-jp/:code(^[0-9]{7}$)', '/api/v1/postalcode-jp/{code}'],
-  ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}'],
+  ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}']
 ]
 
 test('formatParamUrl', t => {

--- a/test/util.js
+++ b/test/util.js
@@ -3,30 +3,24 @@
 const { test } = require('tap')
 const { formatParamUrl } = require('../lib/util/common')
 
+const cases = [
+  ['/example/:userId', '/example/{userId}'],
+  ['/example/:userId/:secretToken', '/example/{userId}/{secretToken}'],
+  ['/example/near/:lat-:lng/radius/:r', '/example/near/{lat}-{lng}/radius/{r}'],
+  ['/example/near/:lat_1-:lng_1/radius/:r_1', '/example/near/{lat_1}-{lng_1}/radius/{r_1}'],
+  ['/example/*', '/example/{wildcard}'],
+  ['/example/:file(^\\d+).png', '/example/{file}.png'],
+  ['/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', '/example/at/{hour}h{minute}m'],
+  ['/example/at/(^\\d{2})h(^\\d{2})m', '/example/at/{regexp1}h{regexp2}m'],
+  ['/name::verb', '/name:verb'],
+  ['/api/v1/postalcode-jp/:code(^[0-9]{7}$)', '/api/v1/postalcode-jp/{code}'],
+  ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}']
+]
+
 test('formatParamUrl', t => {
-  t.plan(4)
+  t.plan(cases.length)
 
-  t.test('support /example/:userId', t => {
-    t.plan(1)
-    const url = formatParamUrl('/example/:userId')
-    t.equal(url, '/example/{userId}')
-  })
-
-  t.test('support /example/:userId/:secretToken', t => {
-    t.plan(1)
-    const url = formatParamUrl('/example/:userId/:secretToken')
-    t.equal(url, '/example/{userId}/{secretToken}')
-  })
-
-  t.test('support /example/near/:lat-:lng/radius/:r', t => {
-    t.plan(1)
-    const url = formatParamUrl('/example/near/:lat-:lng/radius/:r')
-    t.equal(url, '/example/near/{lat}-{lng}/radius/{r}')
-  })
-
-  t.test('support /example/near/:lat_1-:lng_1/radius/:r_1', t => {
-    t.plan(1)
-    const url = formatParamUrl('/example/near/:lat_1-:lng_1/radius/:r_1')
-    t.equal(url, '/example/near/{lat_1}-{lng_1}/radius/{r_1}')
-  })
+  for (const kase of cases) {
+    t.equal(formatParamUrl(kase[0]), kase[1])
+  }
 })


### PR DESCRIPTION
Fixes #510 
I am a bit tired on updating the regexp to accept a lot of different format of param.
I reverted back to use a single `for-loop`

Notable Changes:
1. it support non-named regexp
2. it support `*`

Both of the above cases use auto-generated param name.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
