### PR TITLE
feat(openapi): support patternProperties

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -80,6 +80,12 @@ function normalizeUrl (url, servers, stripBasePath) {
 
 function transformDefsToComponents (jsonSchema) {
   if (typeof jsonSchema === 'object' && jsonSchema !== null) {
+    // Handle patternProperties, that is not part of OpenAPI definitions
+    if (jsonSchema.patternProperties) {
+      jsonSchema.additionalProperties = { type: 'string' }
+      delete jsonSchema.patternProperties
+    }
+
     Object.keys(jsonSchema).forEach(function (key) {
       if (key === '$ref') {
         jsonSchema[key] = jsonSchema[key].replace('definitions', 'components/schemas')

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -155,6 +155,25 @@ function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas, secu
     })
 }
 
+/*
+* Map  unsupported JSON schema definitions to Swagger definitions
+*/
+function replaceUnsupported (jsonSchema) {
+  if (typeof jsonSchema === 'object' && jsonSchema !== null) {
+    // Handle patternProperties, that is not part of OpenAPI definitions
+    if (jsonSchema.patternProperties) {
+      jsonSchema.additionalProperties = { type: 'string' }
+      delete jsonSchema.patternProperties
+    }
+
+    Object.keys(jsonSchema).forEach(function (key) {
+      jsonSchema[key] = replaceUnsupported(jsonSchema[key])
+    })
+  }
+
+  return jsonSchema
+}
+
 function isConsumesFormOnly (schema) {
   const consumes = schema.consumes
   return (
@@ -167,6 +186,8 @@ function isConsumesFormOnly (schema) {
 
 function resolveBodyParams (parameters, schema, ref) {
   const resolved = ref.resolve(schema)
+
+  replaceUnsupported(resolved)
 
   parameters.push({
     name: 'body',
@@ -224,6 +245,7 @@ function resolveResponse (fastifyResponseJson, ref) {
     // add schema when type is not 'null'
     if (rawJsonSchema.type !== 'null') {
       const schema = { ...resolved }
+      replaceUnsupported(schema)
       delete schema[xResponseDescription]
       response.schema = schema
     }


### PR DESCRIPTION
#### Description

This PR solve #165 issue. 

The idea is to transform the patternProperties into a valid OpenAPI definition. We lost the precision in public documentation but validation still done on server side  

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
