### PR TITLE
Added customPropertyOverride functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,10 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
    * Overwrite the route schema
    */
   transform?: Function;
+  /**
+   * Allow overriding swagger properties. Cannot be used together with 'transform'
+   */
+  customPropertyOverrides?:boolean
 }
 
 export interface StaticPathSpec {

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -3,6 +3,32 @@
 const yaml = require('js-yaml')
 const { shouldRouteHide } = require('../../util/common')
 const { prepareDefaultOptions, prepareSwaggerObject, prepareSwaggerMethod, normalizeUrl, prepareSwaggerDefinitions } = require('./utils')
+const merge = require('lodash.merge')
+
+function recursiveCustomPropertyReplacement (schema) {
+  if (typeof schema === 'object') {
+    if (schema.customSwaggerProps !== undefined) {
+      // Update with the custom swagger props, if any
+      schema = merge(schema, schema.customSwaggerProps)
+      delete schema.customSwaggerProps
+    }
+    // Recursively replace properties on children if required
+    const fullyReplaced = Object.fromEntries(
+      Object.entries(schema).map(([key, value]) => {
+        // A reliable way of ensuring it is an object (May not be performant but only used in openapi)
+        if (Object.prototype.toString.call(value) === '[object Object]') {
+          return [key, recursiveCustomPropertyReplacement(value)]
+        }
+
+        return [key, value]
+      })
+    )
+    return fullyReplaced
+  } else {
+    // No further children, return
+    return schema
+  }
+}
 
 module.exports = function (opts, cache, routes, Ref, done) {
   let ref
@@ -25,10 +51,21 @@ module.exports = function (opts, cache, routes, Ref, done) {
     }, ref)
 
     swaggerObject.paths = {}
+
+    if (defOpts.transform && defOpts.customPropertyOverrides) {
+      throw new Error('Using custom property overrides implements a custom transformer. Thus it is not compatible with other custom transformers, see https://github.com/fastify/fastify-swagger/issues/518 on how you could implement custom property overrides into your own transformer')
+    }
+
     for (const route of routes) {
-      const schema = defOpts.transform
-        ? defOpts.transform(route.schema)
-        : route.schema
+      let schema
+
+      if (defOpts.transform) {
+        schema = defOpts.transform(route.schema)
+      } else if (defOpts.customPropertyOverrides) {
+        schema = recursiveCustomPropertyReplacement(route.schema)
+      } else {
+        schema = route.schema
+      }
 
       const shouldRouteHideOpts = {
         hiddenTag: defOpts.hiddenTag,

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -18,6 +18,7 @@ function prepareDefaultOptions (opts) {
   const externalDocs = swagger.externalDocs || null
   const stripBasePath = opts.stripBasePath
   const transform = opts.transform
+  const customPropertyOverrides = opts.customPropertyOverrides
   const hiddenTag = opts.hiddenTag
   const hideUntagged = opts.hideUntagged
   const extensions = []
@@ -42,6 +43,7 @@ function prepareDefaultOptions (opts) {
     externalDocs,
     stripBasePath,
     transform,
+    customPropertyOverrides,
     hiddenTag,
     extensions,
     hideUntagged

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "fastify-static": "^4.0.0",
     "js-yaml": "^4.0.0",
     "json-schema-resolver": "^1.3.0",
+    "lodash.merge": "^4.6.2",
     "openapi-types": "^10.0.0"
   },
   "standard": {


### PR DESCRIPTION
In response to https://github.com/fastify/fastify-swagger/issues/518

This is not complete yet, just an initial implementation, if you guys are okay with the idea itself I can add in the unit tests and stuff

Other things to take note:

- no tests yet
- uses +1 external library (lodash.merge)
- not sure how far back the support goes for `Object.entries`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
