### PR TITLE
OpenApi: Fix params mapping on relative URL

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -63,6 +63,41 @@ const openapiOption = {
   }
 }
 
+const openapiRelaiveOptions = {
+  openapi: {
+    info: {
+      title: 'Test swagger',
+      description: 'testing the fastify swagger api',
+      version: '0.1.0'
+    },
+    servers: [
+      {
+        url: '/test'
+      }
+    ],
+    tags: [
+      { name: 'tag' }
+    ],
+    components: {
+      securitySchemes: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'header'
+        }
+      }
+    },
+    security: [{
+      apiKey: []
+    }],
+    externalDocs: {
+      description: 'Find more info here',
+      url: 'https://swagger.io'
+    }
+  },
+  stripBasePath: false
+}
+
 const schemaQuerystring = {
   schema: {
     response: {
@@ -250,6 +285,7 @@ const schemaOperationId = {
 
 module.exports = {
   openapiOption,
+  openapiRelaiveOptions,
   swaggerOption,
   schemaQuerystring,
   schemaBody,

--- a/examples/options.js
+++ b/examples/options.js
@@ -63,7 +63,7 @@ const openapiOption = {
   }
 }
 
-const openapiRelaiveOptions = {
+const openapiRelativeOptions = {
   openapi: {
     info: {
       title: 'Test swagger',
@@ -285,7 +285,7 @@ const schemaOperationId = {
 
 module.exports = {
   openapiOption,
-  openapiRelaiveOptions,
+  openapiRelativeOptions,
   swaggerOption,
   schemaQuerystring,
   schemaBody,

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -67,7 +67,7 @@ function prepareOpenapiObject (opts) {
 }
 
 function normalizeUrl (url, servers, stripBasePath) {
-  if (!stripBasePath) return url
+  if (!stripBasePath) return formatParamUrl(url)
   servers = Array.isArray(servers) ? servers : []
   servers.forEach(function (server) {
     const basePath = new URL(server.url).pathname

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -7,7 +7,7 @@ const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const {
   openapiOption,
-  openapiRelaiveOptions,
+  openapiRelativeOptions,
   schemaBody,
   schemaConsumes,
   schemaCookies,
@@ -918,7 +918,7 @@ test('path params on relative url', t => {
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiRelaiveOptions)
+  fastify.register(fastifySwagger, openapiRelativeOptions)
 
   const schemaParams = {
     schema: {

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -7,6 +7,7 @@ const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const {
   openapiOption,
+  openapiRelaiveOptions,
   schemaBody,
   schemaConsumes,
   schemaCookies,
@@ -909,6 +910,49 @@ test('security cookies ignored when declared in security and securityScheme', t 
       })
       .catch(function (err) {
         t.error(err)
+      })
+  })
+})
+
+test('path params on relative url', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiRelaiveOptions)
+
+  const schemaParams = {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      }
+    }
+  }
+  fastify.get('/parameters/:id', schemaParams, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    Swagger.validate(openapiObject)
+      .then(function (api) {
+        const paramPath = api.paths['/parameters/{id}'].get
+        t.ok(paramPath)
+        t.same(paramPath.parameters, [
+          {
+            required: true,
+            in: 'path',
+            name: 'id',
+            schema: {
+              type: 'string'
+            }
+          }
+        ])
+      })
+      .catch(function (err) {
+        t.fail(err)
       })
   })
 })


### PR DESCRIPTION
Fix for a bug, when `stripBasePath` is disabled and openApi is configured. it will not map path params to fastify params.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
