### PR TITLE
adds support to externalDocs per route when using OAS 2.0 and updates FastifySchema interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module 'fastify' {
     summary?: string;
     consumes?: string[];
     produces?: string[];
+    externalDocs?: OpenAPIV2.ExternalDocumentationObject | OpenAPIV3.ExternalDocumentationObject;
     security?: Array<{ [securityLabel: string]: string[] }>;
     /**
      * OpenAPI operation unique identifier

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -285,6 +285,7 @@ function prepareSwaggerMethod (schema, ref, swaggerObject) {
     if (schema.operationId) swaggerMethod.operationId = schema.operationId
     if (schema.summary) swaggerMethod.summary = schema.summary
     if (schema.description) swaggerMethod.description = schema.description
+    if (schema.externalDocs) swaggerMethod.externalDocs = schema.externalDocs
     if (schema.tags) swaggerMethod.tags = schema.tags
     if (schema.produces) swaggerMethod.produces = schema.produces
     if (schema.consumes) swaggerMethod.consumes = schema.consumes

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -120,7 +120,7 @@ test('route options - deprecated', t => {
 })
 
 test('route options - meta', t => {
-  t.plan(8)
+  t.plan(9)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, swaggerOption)
@@ -132,7 +132,11 @@ test('route options - meta', t => {
       tags: ['tag'],
       description: 'Route description',
       produces: ['application/octet-stream'],
-      consumes: ['application/x-www-form-urlencoded']
+      consumes: ['application/x-www-form-urlencoded'],
+      externalDocs: {
+        description: 'Find more info here',
+        url: 'https://swagger.io'
+      }
     }
   }
 
@@ -152,6 +156,7 @@ test('route options - meta', t => {
         t.equal(opts.schema.description, definedPath.description)
         t.same(opts.schema.produces, definedPath.produces)
         t.same(opts.schema.consumes, definedPath.consumes)
+        t.equal(opts.schema.externalDocs, definedPath.externalDocs)
       })
       .catch(function (err) {
         t.fail(err)

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -63,6 +63,10 @@ app.put('/some-route/:id', {
       consumes: ['application/json', 'multipart/form-data'],
       security: [{ apiKey: []}],
       operationId: 'opeId',
+      externalDocs: {
+        url: 'https://swagger.io',
+        description: 'Find more info here'
+      },
     }
   }, (req, reply) => {});
 


### PR DESCRIPTION
This pull request adds the possibility of specifying an `externalDocs` object per route when using OAS 2.0 ([as described here](https://swagger.io/specification/v2/#operationObject)) and also exposes this option in the `FastifySchema` interface.

This was already supported by the library when using OAS 3.0 ([as seen here](https://github.com/fastify/fastify-swagger/blob/a0ca54ad45465b8d5a7717c86d1dc57244c843af/lib/spec/openapi/utils.js#L326)), but was not exposed in the `FastifySchema` interface and was also not available when using OAS 2.0.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
