### PR TITLE
feat(open-api): add required on body if necessary

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -209,7 +209,7 @@ function resolveBodyParams (body, schema, consumes, ref) {
       schema: resolved
     }
   })
-  if(resolved?.required?.length){
+  if (resolved?.required?.length) {
     body.required = true
   }
 }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -209,7 +209,7 @@ function resolveBodyParams (body, schema, consumes, ref) {
       schema: resolved
     }
   })
-  if (resolved?.required?.length) {
+  if (resolved && resolved.required && resolved.required.length) {
     body.required = true
   }
 }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -198,18 +198,20 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, secu
     })
 }
 
-function resolveBodyParams (content, schema, consumes, ref) {
+function resolveBodyParams (body, schema, consumes, ref) {
   const resolved = transformDefsToComponents(ref.resolve(schema))
-
   if ((Array.isArray(consumes) && consumes.length === 0) || typeof consumes === 'undefined') {
     consumes = ['application/json']
   }
 
   consumes.forEach((consume) => {
-    content[consume] = {
+    body.content[consume] = {
       schema: resolved
     }
   })
+  if(resolved?.required?.length){
+    body.required = true
+  }
 }
 
 function resolveCommonParams (container, parameters, schema, ref, sharedSchemas, securityIgnores) {
@@ -327,7 +329,7 @@ function prepareOpenapiMethod (schema, ref, openapiObject) {
     if (schema.querystring) resolveCommonParams('query', parameters, schema.querystring, ref, openapiObject.definitions, securityIgnores.query)
     if (schema.body) {
       openapiMethod.requestBody = { content: {} }
-      resolveBodyParams(openapiMethod.requestBody.content, schema.body, schema.consumes, ref)
+      resolveBodyParams(openapiMethod.requestBody, schema.body, schema.consumes, ref)
     }
     if (schema.params) resolveCommonParams('path', parameters, schema.params, ref, openapiObject.definitions)
     if (schema.headers) resolveCommonParams('header', parameters, schema.headers, ref, openapiObject.definitions, securityIgnores.header)

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -190,7 +190,6 @@ function isConsumesFormOnly (schema) {
 
 function resolveBodyParams (parameters, schema, ref) {
   const resolved = ref.resolve(schema)
-
   replaceUnsupported(resolved)
 
   parameters.push({

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -608,22 +608,24 @@ test('uses examples if has multiple array examples', t => {
 })
 
 test('uses examples if has property required in body', t => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.register(fastifySwagger, openapiOption)
 
+  const body = {
+    type: 'object',
+    required: ['hello'],
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    }
+  }
+
   const opts = {
     schema: {
-      body: {
-        type: 'object',
-        required: ['hello'],
-        properties: {
-          hello: {
-            type: 'string'
-          }
-        }
-      }
+      body
     }
   }
 
@@ -638,6 +640,7 @@ test('uses examples if has property required in body', t => {
 
     t.ok(schema)
     t.ok(schema.properties)
+    t.same(body.required, ['hello'])
     t.same(requestBody.required, true)
   })
 })

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -607,4 +607,40 @@ test('uses examples if has multiple array examples', t => {
   })
 })
 
+test('uses examples if has property required in body', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, openapiOption)
+
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: {
+            type: 'string',
+          }
+        }
+      }
+    }
+  }
+
+  fastify.get('/', opts, () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+    const requestBody = openapiObject.paths['/'].get.requestBody
+
+    t.ok(schema)
+    t.ok(schema.properties)
+    t.same(requestBody.required, true)
+  })
+})
+
+
 module.exports = { openapiOption }

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -620,7 +620,7 @@ test('uses examples if has property required in body', t => {
         required: ['hello'],
         properties: {
           hello: {
-            type: 'string',
+            type: 'string'
           }
         }
       }
@@ -641,6 +641,5 @@ test('uses examples if has property required in body', t => {
     t.same(requestBody.required, true)
   })
 })
-
 
 module.exports = { openapiOption }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

This MR add in open-api optional "required" property on schema body if exist at least one required properties in his schema.
It should solve https://github.com/fastify/fastify-swagger/issues/539 issue.
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
