### PR TITLE
Option to hide route using predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,16 @@ An example of using `fastify-swagger` with `static` mode enabled can be found [h
  | exposeRoute        | false            | Exposes documentation route.                                                                                              |
  | hiddenTag          | X-HIDDEN         | Tag to control hiding of routes.                                                                                          |
  | hideUntagged       | false            | If `true` remove routes without tags from resulting Swagger/OpenAPI schema file.                                          |
+ | hideRoutePredicate | null             | predicate function (url, schema) => boolean to decide if should hide route                                                |
  | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).     |
  | openapi            | {}               | [OpenAPI configuration](https://swagger.io/specification/#oasObject).                                                     |
- | routePrefix         | '/documentation' | Overwrite the default Swagger UI route prefix.                                                                            |
+ | routePrefix        | '/documentation' | Overwrite the default Swagger UI route prefix.                                                                            |
  | staticCSP          | false            | Enable CSP header for static resources.                                                                                   |
  | stripBasePath      | true             | Strips base path from routes in docs.                                                                                     |
  | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                              |
  | transform          | null             | Transform method for schema.                                                                                              |
- | transformStaticCSP | undefined         | Synchronous function to transform CSP header for static resources if the header has been previously set.                  |
- | uiConfig            | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
+ | transformStaticCSP | undefined        | Synchronous function to transform CSP header for static resources if the header has been previously set.                  |
+ | uiConfig           | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
  | uiHooks            | {}               | Additional hooks for the documentation's routes. You can provide the `onRequest` and `preHandler` hooks with the same [route's options](https://www.fastify.io/docs/latest/Routes/#options) interface.|
  | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
 
@@ -647,9 +648,17 @@ fastify.get('/user/:id/address', {
 
 <a name="route.hide"></a>
 #### Hide a route
-There are two ways to hide a route from the Swagger UI:
+There are three ways to hide a route from the Swagger UI:
 - Pass `{ hide: true }` to the schema object inside the route declaration.
 - Use the tag declared in `hiddenTag` options property inside the route declaration. Default is `X-HIDDEN`.
+- use `hideRoutePredicate` option to pass a predicate fn (url, schema) => boolean to decide if a route should be hidden.
+  - note: if the `transform` option is used then the transformed schema is the one passed to this predicate 
+
+hiding options cascade: schema hide -> tag -> predicate, returning on the first "true" found.
+
+example: if a route is hidden through the schema hide flag then the other hide options will be ignored.
+
+another example: if the route is hidden through a tag then the hide predicate will be ignored. 
 
 <a name="route.uiHooks"></a>
 #### Protect your documentation routes

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,6 +109,7 @@ export interface FastifyDynamicSwaggerOptions extends FastifySwaggerOptions {
   openapi?: Partial<OpenAPIV3.Document>
   hiddenTag?: string;
   hideUntagged?: boolean;
+  hideRoutePredicate?: (url: string, schema: any) => boolean;
   /**
    * Strips matching base path from routes in documentation
    * @default true

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -11,6 +11,7 @@ module.exports = function (fastify, opts, done) {
     openapi: null,
     swagger: {},
     transform: null,
+    hideRoutePredicate: null,
     refResolver: {
       buildLocalReference (json, baseUri, fragment, i) {
         if (!json.title && json.$id) {

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -32,10 +32,11 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const shouldRouteHideOpts = {
         hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+        hideUntagged: defOpts.hideUntagged,
+        hideRoutePredicate: defOpts.hideRoutePredicate
       }
 
-      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
+      if (shouldRouteHide(route.url, schema, shouldRouteHideOpts)) continue
 
       const url = normalizeUrl(route.url, defOpts.servers, defOpts.stripBasePath)
 

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -16,6 +16,7 @@ function prepareDefaultOptions (opts) {
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
   const hideUntagged = opts.hideUntagged
+  const hideRoutePredicate = opts.hideRoutePredicate
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.openapi)) {
@@ -35,7 +36,8 @@ function prepareDefaultOptions (opts) {
     transform,
     hiddenTag,
     extensions,
-    hideUntagged
+    hideUntagged,
+    hideRoutePredicate
   }
 }
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -32,10 +32,11 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const shouldRouteHideOpts = {
         hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+        hideUntagged: defOpts.hideUntagged,
+        hideRoutePredicate: defOpts.hideRoutePredicate
       }
 
-      if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
+      if (shouldRouteHide(route.url, schema, shouldRouteHideOpts)) continue
 
       const url = normalizeUrl(route.url, defOpts.basePath, defOpts.stripBasePath)
 

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -20,6 +20,7 @@ function prepareDefaultOptions (opts) {
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
   const hideUntagged = opts.hideUntagged
+  const hideRoutePredicate = opts.hideRoutePredicate
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.swagger)) {
@@ -43,8 +44,9 @@ function prepareDefaultOptions (opts) {
     stripBasePath,
     transform,
     hiddenTag,
-    extensions,
-    hideUntagged
+    hideUntagged,
+    hideRoutePredicate,
+    extensions
   }
 }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -44,8 +44,8 @@ function addHook (fastify, pluginOptions) {
   }
 }
 
-function shouldRouteHide (schema, opts) {
-  const { hiddenTag, hideUntagged } = opts
+function shouldRouteHide (url, schema, opts) {
+  const { hiddenTag, hideUntagged, hideRoutePredicate } = opts
 
   if (schema && schema.hide) {
     return true
@@ -58,7 +58,11 @@ function shouldRouteHide (schema, opts) {
   }
 
   if (tags.includes(hiddenTag)) {
-    return schema.tags.includes(hiddenTag)
+    return true
+  }
+
+  if (hideRoutePredicate && typeof hideRoutePredicate === 'function') {
+    return hideRoutePredicate(url, schema)
   }
 
   return false

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -246,6 +246,26 @@ test('hide support - hidden untagged', t => {
   })
 })
 
+test('hide support - hide predicate function', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, { ...openapiOption, hideRoutePredicate: (url) => url.startsWith('/hideme') })
+
+  fastify.get('/public', () => {})
+  fastify.get('/hideme', () => {})
+  fastify.get('/hideme/too', () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const openapiObject = fastify.swagger()
+    t.ok(openapiObject.paths['/public'])
+    t.notOk(openapiObject.paths['/hideme'])
+    t.notOk(openapiObject.paths['/hideme/too'])
+  })
+})
+
 test('basePath support', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -419,6 +419,26 @@ test('hide support - hidden untagged', t => {
   })
 })
 
+test('hide support - hide predicate function', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(fastifySwagger, { ...swaggerOption, hideRoutePredicate: (url) => url.startsWith('/hideme') })
+
+  fastify.get('/public', () => {})
+  fastify.get('/hideme', () => {})
+  fastify.get('/hideme/too', () => {})
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const swaggerObject = fastify.swagger()
+    t.ok(swaggerObject.paths['/public'])
+    t.notOk(swaggerObject.paths['/hideme'])
+    t.notOk(swaggerObject.paths['/hideme/too'])
+  })
+})
+
 test('cache - json', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -51,6 +51,7 @@ const fastifyDynamicSwaggerOptions: SwaggerOptions = {
   exposeRoute: true,
   hiddenTag: 'X-HIDDEN',
   hideUntagged: true,
+  hideRoutePredicate: (_url, _schema) => { return false },
   stripBasePath: true
 }
 app.register(fastifySwagger, fastifyDynamicSwaggerOptions);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

adds the hide predicate option discussed in https://github.com/fastify/fastify-swagger/issues/555

I added typescript typings but didn't find any useful documentation on how to actually test them.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
