### PR TITLE
Link to fastify-openapi-glue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Fastify plugin for serving a [Swagger UI](https://swagger.io/tools/swagger-ui/
 
 Supports Fastify versions `>=3.0.0`. For `fastify@2`, please refer to [`branch@2.x`](https://github.com/fastify/fastify-swagger/tree/2.x) and for `fastify@1.9`, please refer to [`branch@1.x`](https://github.com/fastify/fastify-swagger/tree/1.x).
 
-If you are looking for a plugin to generate routes from an existing OpenAPI schema, check out [fastify-swaggergen](https://github.com/seriousme/fastify-swaggergen).
+If you are looking for a plugin to generate routes from an existing OpenAPI schema, check out [fastify-openapi-glue](https://github.com/seriousme/fastify-openapi-glue).
 
 <a name="install"></a>
 ## Install


### PR DESCRIPTION
[fastify-openapi-glue](https://www.npmjs.com/package/fastify-openapi-glue) instead of deprecated [fastify-swaggergen](https://github.com/seriousme/fastify-swaggergen) by the same author.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
