### PR TITLE
fix: top level schema

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -82,7 +82,7 @@ function transformDefsToComponents (jsonSchema) {
   if (typeof jsonSchema === 'object' && jsonSchema !== null) {
     // Handle patternProperties, that is not part of OpenAPI definitions
     if (jsonSchema.patternProperties) {
-      jsonSchema.additionalProperties = Object.values(jsonSchema.patternProperties)[0];
+      jsonSchema.additionalProperties = Object.values(jsonSchema.patternProperties)[0]
       delete jsonSchema.patternProperties
     } else if (jsonSchema.const) {
       // OAS 3.1 supports `const` but it is not supported by `swagger-ui`

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -31,6 +31,16 @@ function addHook (fastify, pluginOptions) {
     })
   })
 
+  fastify.addHook('onReady', (done) => {
+    const allSchemas = fastify.getSchemas()
+    for (const schemaId of Object.keys(allSchemas)) {
+      if (!sharedSchemasMap.has(schemaId)) {
+        sharedSchemasMap.set(schemaId, allSchemas[schemaId])
+      }
+    }
+    done()
+  })
+
   return {
     routes,
     Ref () {

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -34,9 +34,8 @@ function addHook (fastify, pluginOptions) {
   fastify.addHook('onReady', (done) => {
     const allSchemas = fastify.getSchemas()
     for (const schemaId of Object.keys(allSchemas)) {
-      if (!sharedSchemasMap.has(schemaId)) {
-        sharedSchemasMap.set(schemaId, allSchemas[schemaId])
-      }
+      // it is the top-level, we do not expect to have duplicate id
+      sharedSchemasMap.set(schemaId, allSchemas[schemaId])
     }
     done()
   })


### PR DESCRIPTION
Currently, the top-level `fastify.addSchema` cannot be catched.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
