### PR TITLE
Clone schemas

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -82,7 +82,7 @@ function transformDefsToComponents (jsonSchema) {
   if (typeof jsonSchema === 'object' && jsonSchema !== null) {
     // Handle patternProperties, that is not part of OpenAPI definitions
     if (jsonSchema.patternProperties) {
-      jsonSchema.additionalProperties = Object.values(jsonSchema.patternProperties)[0];
+      jsonSchema.additionalProperties = Object.values(jsonSchema.patternProperties)[0]
       delete jsonSchema.patternProperties
     } else if (jsonSchema.const) {
       // OAS 3.1 supports `const` but it is not supported by `swagger-ui`

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -22,7 +22,7 @@ function addHook (fastify, pluginOptions) {
     // when schemaId is the same in difference instance
     // the latter will lost
     instance.addHook('onReady', (done) => {
-      const allSchemas = cloner(instance.getSchemas())
+      const allSchemas = instance.getSchemas()
       for (const schemaId of Object.keys(allSchemas)) {
         if (!sharedSchemasMap.has(schemaId)) {
           sharedSchemasMap.set(schemaId, allSchemas[schemaId])
@@ -35,7 +35,7 @@ function addHook (fastify, pluginOptions) {
   return {
     routes,
     Ref () {
-      const externalSchemas = Array.from(sharedSchemasMap.values())
+      const externalSchemas = cloner(Array.from(sharedSchemasMap.values()))
       return Ref(Object.assign(
         { applicationUri: 'todo.com' },
         pluginOptions.refResolver,

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const Ref = require('json-schema-resolver')
+const cloner = require('rfdc')({ proto: true, circles: false })
 const { rawRequired } = require('../symbols')
 const { xConsume } = require('../constants')
 
@@ -21,7 +22,7 @@ function addHook (fastify, pluginOptions) {
     // when schemaId is the same in difference instance
     // the latter will lost
     instance.addHook('onReady', (done) => {
-      const allSchemas = instance.getSchemas()
+      const allSchemas = cloner(instance.getSchemas())
       for (const schemaId of Object.keys(allSchemas)) {
         if (!sharedSchemasMap.has(schemaId)) {
           sharedSchemasMap.set(schemaId, allSchemas[schemaId])

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "fastify-static": "^4.0.0",
     "js-yaml": "^4.0.0",
     "json-schema-resolver": "^1.3.0",
-    "openapi-types": "^10.0.0"
+    "openapi-types": "^10.0.0",
+    "rfdc": "^1.3.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Without the fix the test would have returned a 400 error for the second POST call. This is because running swagger mutates the schema in the global Fastify instance, and breaks the validation. 
This fix clones the schema when we load it in the Fastify swagger package and prevents mutation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
