### PR TITLE
feat: support fastify v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add it to your project with `register`, pass it some options, call the `swagger`
 ```js
 const fastify = require('fastify')()
 
-fastify.register(require('@fastify/swagger'), {
+await fastify.register(require('@fastify/swagger'), {
   routePrefix: '/documentation',
   swagger: {
     info: {
@@ -126,10 +126,8 @@ fastify.put('/some-route/:id', {
   }
 }, (req, reply) => {})
 
-fastify.ready(err => {
-  if (err) throw err
-  fastify.swagger()
-})
+await fastify.ready()
+fastify.swagger()
 ```
 <a name="api"></a>
 ## API
@@ -257,7 +255,7 @@ Examples of all the possible uses mentioned:
 ```js
 const convert = require('joi-to-json')
 
-fastify.register(require('@fastify/swagger'), {
+await fastify.register(require('@fastify/swagger'), {
   swagger: { ... },
   transform: ({ schema, url }) => {
     const {
@@ -302,7 +300,7 @@ By default, this option will resolve all `$ref`s renaming them to `def-${counter
 To customize this logic you can pass a `refResolver` option to the plugin:
 
 ```js
-fastify.register(require('@fastify/swagger'), {
+await fastify.register(require('@fastify/swagger'), {
   swagger: { ... },
   ...
   refResolver: {
@@ -691,7 +689,7 @@ await fastify.register(require('@fastify/basic-auth'), {
   authenticate: true
 })
 
-fastify.register(fastifySwagger, {
+await fastify.register(fastifySwagger, {
   exposeRoute: true,
   uiHooks: {
     onRequest: fastify.basicAuth

--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ function fastifySwagger (fastify, opts, next) {
 }
 
 module.exports = fp(fastifySwagger, {
-  fastify: '>=3.x',
-  name: 'fastify-swagger'
+  fastify: '4.x',
+  name: '@fastify/swagger'
 })

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -12,6 +12,10 @@ function addHook (fastify, pluginOptions) {
   const sharedSchemasMap = new Map()
 
   fastify.addHook('onRoute', (routeOptions) => {
+    // we need to skip HEAD route
+    // since it may automatically added by fastify
+    // and will conflict with the existing route
+    if (routeOptions.method === 'HEAD') return
     routes.push(routeOptions)
   })
 

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
-    "@fastify/basic-auth": "^3.0.2",
-    "@fastify/helmet": "^8.0.0",
+    "@fastify/basic-auth": "^4.0.0",
+    "@fastify/helmet": "^9.0.0",
     "@types/node": "^17.0.13",
-    "fastify": "^3.29.0",
+    "fastify": "^4.0.0-rc.2",
     "fluent-json-schema": "^3.1.0",
     "fs-extra": "^10.1.0",
     "joi": "^17.6.0",
@@ -59,7 +59,7 @@
     "tsd": "^0.20.0"
   },
   "dependencies": {
-    "@fastify/static": "^5.0.0",
+    "@fastify/static": "^6.0.0",
     "fastify-plugin": "^3.0.1",
     "js-yaml": "^4.1.0",
     "json-schema-resolver": "^1.3.0",

--- a/test/csp.js
+++ b/test/csp.js
@@ -20,11 +20,11 @@ swaggerOption = {
   exposeRoute: true
 }
 
-test('staticCSP = undefined', t => {
-  t.plan(4)
+test('staticCSP = undefined', async (t) => {
+  t.plan(3)
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -33,22 +33,20 @@ test('staticCSP = undefined', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(typeof res.headers['content-security-policy'], 'undefined')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 200)
+  t.equal(typeof res.headers['content-security-policy'], 'undefined')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('staticCSP = true', t => {
-  t.plan(7)
+test('staticCSP = true', async (t) => {
+  t.plan(5)
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     staticCSP: true
   })
@@ -60,31 +58,31 @@ test('staticCSP = true', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/index.html'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], `default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(' ')}; upgrade-insecure-requests;`)
     t.equal(typeof res.payload, 'string')
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
     t.equal(res.statusCode, 200)
     t.equal(typeof res.headers['content-security-policy'], 'undefined')
-  })
+  }
 })
 
-test('staticCSP = "default-src \'self\';"', t => {
-  t.plan(7)
+test('staticCSP = "default-src \'self\';"', async (t) => {
+  t.plan(5)
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     staticCSP: "default-src 'self';"
   })
@@ -96,31 +94,31 @@ test('staticCSP = "default-src \'self\';"', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/index.html'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self';")
     t.equal(typeof res.payload, 'string')
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
     t.equal(res.statusCode, 200)
     t.equal(typeof res.headers['content-security-policy'], 'undefined')
-  })
+  }
 })
 
-test('staticCSP = object', t => {
-  t.plan(7)
+test('staticCSP = object', async (t) => {
+  t.plan(5)
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     staticCSP: {
       'default-src': ["'self'"],
@@ -135,31 +133,31 @@ test('staticCSP = object', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/index.html'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
     t.equal(typeof res.payload, 'string')
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
     t.equal(res.statusCode, 200)
     t.equal(typeof res.headers['content-security-policy'], 'undefined')
-  })
+  }
 })
 
-test('transformStaticCSP = function', t => {
-  t.plan(8)
+test('transformStaticCSP = function', async (t) => {
+  t.plan(6)
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     staticCSP: "default-src 'self';",
     transformStaticCSP: function (header) {
@@ -175,32 +173,32 @@ test('transformStaticCSP = function', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/index.html'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
     t.equal(typeof res.payload, 'string')
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
     t.equal(res.statusCode, 200)
     t.equal(typeof res.headers['content-security-policy'], 'undefined')
-  })
+  }
 })
 
-test('transformStaticCSP = function, with @fastify/helmet', t => {
-  t.plan(8)
+test('transformStaticCSP = function, with @fastify/helmet', async (t) => {
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(fastifyHelmet)
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     transformStaticCSP: function (header) {
       t.equal(header, "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests")
@@ -215,22 +213,22 @@ test('transformStaticCSP = function, with @fastify/helmet', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/index.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/index.html'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
     t.equal(typeof res.payload, 'string')
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests")
-  })
+  }
 })

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -4,26 +4,22 @@ const { test } = require('tap')
 const Fastify = require('fastify')
 const fastifySwagger = require('../index')
 
-test('fastify.swagger should exist', t => {
-  t.plan(2)
+test('fastify.swagger should exist', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger)
+  await fastify.register(fastifySwagger)
 
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.swagger)
-  })
+  await fastify.ready()
+  t.ok(fastify.swagger)
 })
 
-test('fastify.swaggerCSP should exist', t => {
-  t.plan(2)
+test('fastify.swaggerCSP should exist', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger)
+  await fastify.register(fastifySwagger)
 
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.swaggerCSP)
-  })
+  await fastify.ready()
+  t.ok(fastify.swaggerCSP)
 })

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -5,7 +5,7 @@ import swaggerDefault from '../../index.js'
 t.test('esm support', async t => {
   const fastify = Fastify()
 
-  fastify.register(swaggerDefault)
+  await fastify.register(swaggerDefault)
 
   await fastify.ready()
 

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -1,19 +1,11 @@
 'use strict'
 
-const t = require('tap')
-const semver = require('semver')
-
-if (semver.lt(process.versions.node, '13.3.0')) {
-  t.skip('Skip because Node version <= 13.3.0')
-  t.end()
-} else {
-  // Node v8 throw a `SyntaxError: Unexpected token import`
-  // even if this branch is never touch in the code,
-  // by using `eval` we can avoid this issue.
-  // eslint-disable-next-line
-  new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
-    process.nextTick(() => {
-      throw err
-    })
+// Node v8 throw a `SyntaxError: Unexpected token import`
+// even if this branch is never touch in the code,
+// by using `eval` we can avoid this issue.
+// eslint-disable-next-line
+new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
+  process.nextTick(() => {
+    throw err
   })
-}
+})

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -25,7 +25,7 @@ function basicAuthEncode (username, password) {
 test('hooks on static swagger', async t => {
   const fastify = Fastify()
   await fastify.register(require('@fastify/basic-auth'), authOptions)
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     mode: 'static',
     specification: {
       path: './examples/example-static-specification.yaml'
@@ -76,7 +76,7 @@ test('hooks on dynamic swagger', async t => {
   const fastify = Fastify()
   await fastify.register(require('@fastify/basic-auth'), authOptions)
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...swaggerOption,
     exposeRoute: true,
     uiHooks: {
@@ -84,7 +84,7 @@ test('hooks on dynamic swagger', async t => {
     }
   })
 
-  fastify.get('/fooBar123', schemaBody, () => {})
+  fastify.post('/fooBar123', schemaBody, () => {})
 
   let res = await fastify.inject('/documentation')
   t.equal(res.statusCode, 401, 'root auth required')
@@ -109,7 +109,7 @@ test('hooks on dynamic swagger', async t => {
 
 test('catch all added schema', async t => {
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: {},
     refResolver: {
       buildLocalReference: (json, baseUri, fragment, i) => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,8 +5,8 @@ const Fastify = require('fastify')
 const fastifySwagger = require('..')
 const fastifyHelmet = require('@fastify/helmet')
 const swaggerCSP = require('../static/csp.json')
-test('fastify will response swagger csp', t => {
-  t.plan(2)
+test('fastify will response swagger csp', async (t) => {
+  t.plan(1)
 
   const scriptCSP = swaggerCSP.script.length > 0 ? ` ${swaggerCSP.script.join(' ')}` : ''
   const styleCSP = swaggerCSP.style.length > 0 ? ` ${swaggerCSP.style.join(' ')}` : ''
@@ -14,7 +14,7 @@ test('fastify will response swagger csp', t => {
 
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger)
+  await fastify.register(fastifySwagger)
   fastify.register(fastifyHelmet, instance => {
     return {
       contentSecurityPolicy: {
@@ -35,11 +35,9 @@ test('fastify will response swagger csp', t => {
     })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.same(res.headers['content-security-policy'], csp)
   })
+  t.same(res.headers['content-security-policy'], csp)
 })

--- a/test/route.js
+++ b/test/route.js
@@ -55,11 +55,11 @@ const schemaParamsWithKey = {
   }
 }
 
-test('/documentation/json route', t => {
-  t.plan(2)
+test('/documentation/json route', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -68,26 +68,19 @@ test('/documentation/json route', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/json'
-  }, (err, res) => {
-    t.error(err)
-
-    const payload = JSON.parse(res.payload)
-
-    Swagger.validate(payload)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
   })
+
+  const payload = JSON.parse(res.payload)
+
+  await Swagger.validate(payload)
+  t.pass('valid swagger object')
 })
 
-test('/documentation/uiConfig route', t => {
-  t.plan(2)
+test('/documentation/uiConfig route', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
   const uiConfig = {
@@ -99,7 +92,7 @@ test('/documentation/uiConfig route', t => {
     uiConfig
   }
 
-  fastify.register(fastifySwagger, opts)
+  await fastify.register(fastifySwagger, opts)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -108,20 +101,18 @@ test('/documentation/uiConfig route', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/uiConfig'
-  }, (err, res) => {
-    t.error(err)
-
-    const payload = JSON.parse(res.payload)
-
-    t.match(payload, uiConfig, 'uiConfig should be valid')
   })
+
+  const payload = JSON.parse(res.payload)
+
+  t.match(payload, uiConfig, 'uiConfig should be valid')
 })
 
-test('/documentation/initOAuth route', t => {
-  t.plan(2)
+test('/documentation/initOAuth route', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
   const initOAuth = {
@@ -133,7 +124,7 @@ test('/documentation/initOAuth route', t => {
     initOAuth
   }
 
-  fastify.register(fastifySwagger, opts)
+  await fastify.register(fastifySwagger, opts)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -142,23 +133,21 @@ test('/documentation/initOAuth route', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/initOAuth'
-  }, (err, res) => {
-    t.error(err)
-
-    const payload = JSON.parse(res.payload)
-
-    t.match(payload, initOAuth, 'initOAuth should be valid')
   })
+
+  const payload = JSON.parse(res.payload)
+
+  t.match(payload, initOAuth, 'initOAuth should be valid')
 })
 
-test('fastify.swagger should return a valid swagger yaml', t => {
-  t.plan(4)
+test('fastify.swagger should return a valid swagger yaml', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -168,26 +157,21 @@ test('fastify.swagger should return a valid swagger yaml', t => {
   fastify.get('/example1', schemaSecurity, () => {})
   fastify.all('/parametersWithoutDesc/:id', schemaParamsWithoutDesc, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/yaml'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(typeof res.payload, 'string')
-    t.equal(res.headers['content-type'], 'application/x-yaml')
-    try {
-      yaml.load(res.payload)
-      t.pass('valid swagger yaml')
-    } catch (err) {
-      t.fail(err)
-    }
   })
+
+  t.equal(typeof res.payload, 'string')
+  t.equal(res.headers['content-type'], 'application/x-yaml')
+  yaml.load(res.payload)
+  t.pass('valid swagger yaml')
 })
 
-test('/documentation should redirect to ./documentation/static/index.html', t => {
-  t.plan(4)
+test('/documentation should redirect to ./documentation/static/index.html', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -196,21 +180,19 @@ test('/documentation should redirect to ./documentation/static/index.html', t =>
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './documentation/static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/documentation/ should redirect to ./static/index.html', t => {
-  t.plan(4)
+test('/documentation/ should redirect to ./static/index.html', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -219,23 +201,21 @@ test('/documentation/ should redirect to ./static/index.html', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/v1/documentation should redirect to ./documentation/static/index.html', t => {
-  t.plan(4)
+test('/v1/documentation should redirect to ./documentation/static/index.html', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
   const opts = JSON.parse(JSON.stringify(swaggerOption))
   opts.routePrefix = '/v1/documentation'
-  fastify.register(fastifySwagger, opts)
+  await fastify.register(fastifySwagger, opts)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -244,23 +224,21 @@ test('/v1/documentation should redirect to ./documentation/static/index.html', t
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/v1/documentation'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './documentation/static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/v1/documentation/ should redirect to ./static/index.html', t => {
-  t.plan(4)
+test('/v1/documentation/ should redirect to ./static/index.html', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
   const opts = JSON.parse(JSON.stringify(swaggerOption))
   opts.routePrefix = '/v1/documentation'
-  fastify.register(fastifySwagger, opts)
+  await fastify.register(fastifySwagger, opts)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -269,25 +247,23 @@ test('/v1/documentation/ should redirect to ./static/index.html', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/v1/documentation/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', t => {
-  t.plan(4)
+test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(function (fastify, options, next) {
+  fastify.register(async function (fastify, options) {
     const opts = JSON.parse(JSON.stringify(swaggerOption))
     opts.routePrefix = '/foobar'
-    fastify.register(fastifySwagger, opts)
+    await fastify.register(fastifySwagger, opts)
 
     fastify.get('/', () => {})
     fastify.post('/', () => {})
@@ -295,29 +271,25 @@ test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', t =
     fastify.post('/example', schemaBody, () => {})
     fastify.get('/parameters/:id', schemaParams, () => {})
     fastify.get('/example1', schemaSecurity, () => {})
-
-    next()
   }, { prefix: '/v1' })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/v1/foobar'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './foobar/static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './foobar/static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/v1/foobar/ should redirect to ./static/index.html - in plugin', t => {
-  t.plan(4)
+test('/v1/foobar/ should redirect to ./static/index.html - in plugin', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(function (fastify, options, next) {
+  fastify.register(async function (fastify, options) {
     const opts = JSON.parse(JSON.stringify(swaggerOption))
     opts.routePrefix = '/foobar'
-    fastify.register(fastifySwagger, opts)
+    await fastify.register(fastifySwagger, opts)
 
     fastify.get('/', () => {})
     fastify.post('/', () => {})
@@ -325,47 +297,41 @@ test('/v1/foobar/ should redirect to ./static/index.html - in plugin', t => {
     fastify.post('/example', schemaBody, () => {})
     fastify.get('/parameters/:id', schemaParams, () => {})
     fastify.get('/example1', schemaSecurity, () => {})
-
-    next()
   }, { prefix: '/v1' })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/v1/foobar/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('with routePrefix: \'/\' should redirect to ./static/index.html', t => {
-  t.plan(4)
+test('with routePrefix: \'/\' should redirect to ./static/index.html', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
   const opts = JSON.parse(JSON.stringify(swaggerOption))
   opts.routePrefix = '/'
-  fastify.register(fastifySwagger, opts)
+  await fastify.register(fastifySwagger, opts)
 
   fastify.get('/foo', () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
-    t.equal(typeof res.payload, 'string')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+  t.equal(typeof res.payload, 'string')
 })
 
-test('/documentation/static/:file should send back the correct file', t => {
-  t.plan(29)
+test('/documentation/static/:file should send back the correct file', async (t) => {
+  t.plan(22)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -374,39 +340,39 @@ test('/documentation/static/:file should send back the correct file', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/'
-  }, (err, res) => {
-    t.error(err)
+  await fastify.ready()
+
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/'
+    })
     t.equal(res.statusCode, 302)
     t.equal(res.headers.location, './static/index.html')
-  })
+  }
 
-  fastify.ready(() => {
-    fastify.inject({
+  {
+    const res = await fastify.inject({
       method: 'GET',
       url: '/documentation/static/'
-    }, (err, res) => {
-      t.error(err)
-      t.equal(typeof res.payload, 'string')
-      t.equal(res.headers['content-type'], 'text/html; charset=UTF-8')
-      t.equal(
-        readFileSync(
-          resolve(__dirname, '..', 'static', 'index.html'),
-          'utf8'
-        ),
-        res.payload
-      )
-      t.ok(res.payload.indexOf('swagger-initializer.js') !== -1)
     })
-  })
+    t.equal(typeof res.payload, 'string')
+    t.equal(res.headers['content-type'], 'text/html; charset=UTF-8')
+    t.equal(
+      readFileSync(
+        resolve(__dirname, '..', 'static', 'index.html'),
+        'utf8'
+      ),
+      res.payload
+    )
+    t.ok(res.payload.indexOf('swagger-initializer.js') !== -1)
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/swagger-initializer.js'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/swagger-initializer.js'
+    })
     t.equal(typeof res.payload, 'string')
     t.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8')
     t.equal(
@@ -417,13 +383,13 @@ test('/documentation/static/:file should send back the correct file', t => {
       res.payload
     )
     t.ok(res.payload.indexOf('resolveUrl') !== -1)
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/oauth2-redirect.html'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/oauth2-redirect.html'
+    })
     t.equal(typeof res.payload, 'string')
     t.equal(res.headers['content-type'], 'text/html; charset=UTF-8')
     t.equal(
@@ -433,13 +399,13 @@ test('/documentation/static/:file should send back the correct file', t => {
       ),
       res.payload
     )
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/swagger-ui.css'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/swagger-ui.css'
+    })
     t.equal(typeof res.payload, 'string')
     t.equal(res.headers['content-type'], 'text/css; charset=UTF-8')
     t.equal(
@@ -449,13 +415,13 @@ test('/documentation/static/:file should send back the correct file', t => {
       ),
       res.payload
     )
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/swagger-ui-bundle.js'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/swagger-ui-bundle.js'
+    })
     t.equal(typeof res.payload, 'string')
     t.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8')
     t.equal(
@@ -465,13 +431,13 @@ test('/documentation/static/:file should send back the correct file', t => {
       ),
       res.payload
     )
-  })
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/documentation/static/swagger-ui-standalone-preset.js'
-  }, (err, res) => {
-    t.error(err)
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/swagger-ui-standalone-preset.js'
+    })
     t.equal(typeof res.payload, 'string')
     t.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8')
     t.equal(
@@ -481,14 +447,14 @@ test('/documentation/static/:file should send back the correct file', t => {
       ),
       res.payload
     )
-  })
+  }
 })
 
-test('/documentation/static/:file 404', t => {
-  t.plan(3)
+test('/documentation/static/:file 404', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -497,26 +463,24 @@ test('/documentation/static/:file 404', t => {
   fastify.get('/parameters/:id', schemaParams, () => {})
   fastify.get('/example1', schemaSecurity, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/static/stuff.css'
-  }, (err, res) => {
-    t.error(err)
-    const payload = JSON.parse(res.payload)
-    t.equal(res.statusCode, 404)
-    t.match(payload, {
-      error: 'Not Found',
-      statusCode: 404
-    })
+  })
+  const payload = JSON.parse(res.payload)
+  t.equal(res.statusCode, 404)
+  t.match(payload, {
+    error: 'Not Found',
+    statusCode: 404
   })
 })
 
-test('/documentation2/json route (overwrite)', t => {
-  t.plan(2)
+test('/documentation2/json route (overwrite)', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
   const swaggerOptionWithRouteOverwrite = JSON.parse(JSON.stringify(swaggerOption))
   swaggerOptionWithRouteOverwrite.routePrefix = '/documentation2'
-  fastify.register(fastifySwagger, swaggerOptionWithRouteOverwrite)
+  await fastify.register(fastifySwagger, swaggerOptionWithRouteOverwrite)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -526,67 +490,54 @@ test('/documentation2/json route (overwrite)', t => {
   fastify.get('/example1', schemaSecurity, () => {})
   fastify.get('/parameters/:id/:key', schemaParamsWithKey, () => {})
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation2/json'
-  }, (err, res) => {
-    t.error(err)
-
-    const payload = JSON.parse(res.payload)
-
-    Swagger.validate(payload)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
   })
+
+  const payload = JSON.parse(res.payload)
+
+  await Swagger.validate(payload)
+  t.pass('valid swagger object')
 })
 
-test('/documentation/:myfile should return 404 in dynamic mode', t => {
-  t.plan(2)
+test('/documentation/:myfile should return 404 in dynamic mode', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/swagger-ui.js'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
   })
+  t.equal(res.statusCode, 404)
 })
 
-test('/documentation/:myfile should run custom NotFoundHandler in dynamic mode', t => {
-  t.plan(2)
+test('/documentation/:myfile should run custom NotFoundHandler in dynamic mode', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
   const notFoundHandler = function (req, reply) {
     reply.code(410).send()
   }
   fastify.setNotFoundHandler(notFoundHandler)
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/swagger-ui.js'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 410)
   })
+  t.equal(res.statusCode, 410)
 })
 
-test('/documentation/ should redirect to ./static/index.html', t => {
-  t.plan(3)
+test('/documentation/ should redirect to ./static/index.html', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/documentation/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
   })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
 })

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -8,41 +8,37 @@ const fastifySwagger = require('../../../index')
 const { readPackageJson } = require('../../../lib/util/common')
 const { openapiOption } = require('../../../examples/options')
 
-test('openapi should have default version', t => {
+test('openapi should have default version', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, { openapi: {} })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  t.equal(openapiObject.openapi, '3.0.3')
+})
+
+test('openapi should have default info properties', async (t) => {
   t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, { openapi: {} })
+  await fastify.register(fastifySwagger, { openapi: {} })
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(openapiObject.openapi, '3.0.3')
-  })
+  const openapiObject = fastify.swagger()
+  const pkg = readPackageJson()
+  t.equal(openapiObject.info.title, pkg.name)
+  t.equal(openapiObject.info.version, pkg.version)
 })
 
-test('openapi should have default info properties', t => {
-  t.plan(3)
+test('openapi basic properties', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, { openapi: {} })
-
-  fastify.ready(err => {
-    t.error(err)
-
-    const openapiObject = fastify.swagger()
-    const pkg = readPackageJson(function () {})
-    t.equal(openapiObject.info.title, pkg.name)
-    t.equal(openapiObject.info.version, pkg.version)
-  })
-})
-
-test('openapi basic properties', t => {
-  t.plan(5)
-  const fastify = Fastify()
-
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -61,21 +57,19 @@ test('openapi basic properties', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(openapiObject.info, openapiOption.openapi.info)
-    t.equal(openapiObject.servers, openapiOption.openapi.servers)
-    t.ok(openapiObject.paths)
-    t.ok(openapiObject.paths['/'])
-  })
+  const openapiObject = fastify.swagger()
+  t.equal(openapiObject.info, openapiOption.openapi.info)
+  t.equal(openapiObject.servers, openapiOption.openapi.servers)
+  t.ok(openapiObject.paths)
+  t.ok(openapiObject.paths['/'])
 })
 
-test('openapi components', t => {
-  t.plan(2)
+test('openapi components', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
   openapiOption.openapi.components.schemas = {
@@ -94,24 +88,22 @@ test('openapi components', t => {
     }
   }
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.same(openapiObject.components.schemas, openapiOption.openapi.components.schemas)
-    delete openapiOption.openapi.components.schemas // remove what we just added
-  })
+  const openapiObject = fastify.swagger()
+  t.same(openapiObject.components.schemas, openapiOption.openapi.components.schemas)
+  delete openapiOption.openapi.components.schemas // remove what we just added
 })
 
-test('hide support when property set in transform() - property', t => {
-  t.plan(2)
+test('hide support when property set in transform() - property', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     ...openapiOption,
     transform: ({ schema, url }) => {
       return { schema: { ...schema, hide: true }, url }
@@ -135,21 +127,19 @@ test('hide support when property set in transform() - property', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths['/'])
 })
 
-test('hide support - tags Default', t => {
-  t.plan(2)
+test('hide support - tags Default', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -169,21 +159,19 @@ test('hide support - tags Default', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths['/'])
 })
 
-test('hide support - tags Custom', t => {
-  t.plan(2)
+test('hide support - tags Custom', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, { ...openapiOption, hiddenTag: 'NOP' })
+  await fastify.register(fastifySwagger, { ...openapiOption, hiddenTag: 'NOP' })
 
   const opts = {
     schema: {
@@ -203,21 +191,19 @@ test('hide support - tags Custom', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths['/'])
 })
 
-test('hide support - hidden untagged', t => {
-  t.plan(2)
+test('hide support - hidden untagged', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, { ...openapiOption, hideUntagged: true })
+  await fastify.register(fastifySwagger, { ...openapiOption, hideUntagged: true })
 
   const opts = {
     schema: {
@@ -236,21 +222,19 @@ test('hide support - hidden untagged', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths['/'])
 })
 
-test('basePath support', t => {
-  t.plan(3)
+test('basePath support', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: Object.assign({}, openapiOption.openapi, {
       servers: [
         {
@@ -262,21 +246,19 @@ test('basePath support', t => {
 
   fastify.get('/prefix/endpoint', {}, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths['/prefix/endpoint'])
-    t.ok(openapiObject.paths['/endpoint'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths['/prefix/endpoint'])
+  t.ok(openapiObject.paths['/endpoint'])
 })
 
-test('basePath maintained when stripBasePath is set to false', t => {
-  t.plan(4)
+test('basePath maintained when stripBasePath is set to false', async (t) => {
+  t.plan(3)
 
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     stripBasePath: false,
     openapi: Object.assign({}, openapiOption.openapi, {
       servers: [
@@ -289,66 +271,50 @@ test('basePath maintained when stripBasePath is set to false', t => {
 
   fastify.get('/foo/endpoint', {}, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.notOk(openapiObject.paths.endpoint)
-    t.notOk(openapiObject.paths['/endpoint'])
-    t.ok(openapiObject.paths['/foo/endpoint'])
-  })
+  const openapiObject = fastify.swagger()
+  t.notOk(openapiObject.paths.endpoint)
+  t.notOk(openapiObject.paths['/endpoint'])
+  t.ok(openapiObject.paths['/foo/endpoint'])
 })
 
-test('cache - json', t => {
+test('cache - json', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  await fastify.ready()
+
+  fastify.swagger()
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
+
+  await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+})
+
+test('cache - yaml', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  await fastify.ready()
+
+  fastify.swagger({ yaml: true })
+  const swaggerYaml = fastify.swagger({ yaml: true })
+  t.equal(typeof swaggerYaml, 'string')
+  yaml.load(swaggerYaml)
+  t.pass('valid swagger yaml')
+})
+
+test('transforms examples in example if single string example', async (t) => {
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
-
-  fastify.ready(err => {
-    t.error(err)
-
-    fastify.swagger()
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
-
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
-})
-
-test('cache - yaml', t => {
-  t.plan(3)
-  const fastify = Fastify()
-
-  fastify.register(fastifySwagger, openapiOption)
-
-  fastify.ready(err => {
-    t.error(err)
-
-    fastify.swagger({ yaml: true })
-    const swaggerYaml = fastify.swagger({ yaml: true })
-    t.equal(typeof swaggerYaml, 'string')
-
-    try {
-      yaml.load(swaggerYaml)
-      t.pass('valid swagger yaml')
-    } catch (err) {
-      t.fail(err)
-    }
-  })
-})
-
-test('transforms examples in example if single string example', t => {
-  t.plan(4)
-  const fastify = Fastify()
-
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -365,25 +331,23 @@ test('transforms examples in example if single string example', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.notOk(schema.properties.hello.examples)
-    t.equal(schema.properties.hello.example, 'world')
-  })
+  t.ok(schema)
+  t.notOk(schema.properties.hello.examples)
+  t.equal(schema.properties.hello.example, 'world')
 })
 
-test('transforms examples in example if single object example', t => {
-  t.plan(4)
+test('transforms examples in example if single object example', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -405,25 +369,23 @@ test('transforms examples in example if single object example', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.notOk(schema.properties.hello.examples)
-    t.same(schema.properties.hello.example, { lorem: 'ipsum' })
-  })
+  t.ok(schema)
+  t.notOk(schema.properties.hello.examples)
+  t.same(schema.properties.hello.example, { lorem: 'ipsum' })
 })
 
-test('uses examples if has multiple string examples', t => {
-  t.plan(4)
+test('uses examples if has multiple string examples', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -440,32 +402,30 @@ test('uses examples if has multiple string examples', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, {
-      hello: {
-        value: 'hello'
-      },
-      world: {
-        value: 'world'
-      }
-    })
+  t.ok(schema)
+  t.ok(schema.properties.hello.examples)
+  t.same(schema.properties.hello.examples, {
+    hello: {
+      value: 'hello'
+    },
+    world: {
+      value: 'world'
+    }
   })
 })
 
-test('uses examples if has multiple numbers examples', t => {
-  t.plan(4)
+test('uses examples if has multiple numbers examples', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -482,32 +442,30 @@ test('uses examples if has multiple numbers examples', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, {
-      1: {
-        value: 1
-      },
-      2: {
-        value: 2
-      }
-    })
+  t.ok(schema)
+  t.ok(schema.properties.hello.examples)
+  t.same(schema.properties.hello.examples, {
+    1: {
+      value: 1
+    },
+    2: {
+      value: 2
+    }
   })
 })
 
-test('uses examples if has multiple object examples', t => {
-  t.plan(4)
+test('uses examples if has multiple object examples', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -529,36 +487,34 @@ test('uses examples if has multiple object examples', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, {
-      example1: {
-        value: {
-          lorem: 'ipsum'
-        }
-      },
-      example2: {
-        value: {
-          hello: 'world'
-        }
+  t.ok(schema)
+  t.ok(schema.properties.hello.examples)
+  t.same(schema.properties.hello.examples, {
+    example1: {
+      value: {
+        lorem: 'ipsum'
       }
-    })
+    },
+    example2: {
+      value: {
+        hello: 'world'
+      }
+    }
   })
 })
 
-test('uses examples if has multiple array examples', t => {
-  t.plan(4)
+test('uses examples if has multiple array examples', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -578,40 +534,38 @@ test('uses examples if has multiple array examples', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
 
-    t.ok(schema)
-    t.ok(schema.properties.hello.examples)
-    t.same(schema.properties.hello.examples, {
-      example1: {
-        value: [
-          'a',
-          'b',
-          'c'
-        ]
-      },
-      example2: {
-        value: [
-          'd',
-          'f',
-          'g'
-        ]
-      }
-    })
+  t.ok(schema)
+  t.ok(schema.properties.hello.examples)
+  t.same(schema.properties.hello.examples, {
+    example1: {
+      value: [
+        'a',
+        'b',
+        'c'
+      ]
+    },
+    example2: {
+      value: [
+        'd',
+        'f',
+        'g'
+      ]
+    }
   })
 })
 
-test('uses examples if has property required in body', t => {
-  t.plan(5)
+test('uses examples if has property required in body', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const body = {
     type: 'object',
@@ -629,20 +583,18 @@ test('uses examples if has property required in body', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    const schema = openapiObject.paths['/'].get.requestBody.content['application/json'].schema
-    const requestBody = openapiObject.paths['/'].get.requestBody
+  const openapiObject = fastify.swagger()
+  const schema = openapiObject.paths['/'].post.requestBody.content['application/json'].schema
+  const requestBody = openapiObject.paths['/'].post.requestBody
 
-    t.ok(schema)
-    t.ok(schema.properties)
-    t.same(body.required, ['hello'])
-    t.same(requestBody.required, true)
-  })
+  t.ok(schema)
+  t.ok(schema.properties)
+  t.same(body.required, ['hello'])
+  t.same(requestBody.required, true)
 })
 
 module.exports = { openapiOption }

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -17,7 +17,7 @@ const openapiOption = {
 test('support $ref schema', async (t) => {
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'Order', type: 'object', properties: { id: { type: 'integer' } } })
     instance.post('/', { schema: { body: { $ref: 'Order#' }, response: { 200: { $ref: 'Order#' } } } }, () => {})
@@ -35,7 +35,7 @@ test('support $ref schema', async (t) => {
 test('support $ref relative pointers in params', async (t) => {
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
   fastify.register(async (instance) => {
     instance.addSchema({
       $id: 'Order',
@@ -65,7 +65,7 @@ test('support $ref relative pointers in params', async (t) => {
 
 test('support nested $ref schema : simple test', async (t) => {
   const fastify = Fastify()
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'OrderItem', type: 'object', properties: { id: { type: 'integer' } } })
     instance.addSchema({ $id: 'ProductItem', type: 'object', properties: { id: { type: 'integer' } } })
@@ -90,7 +90,7 @@ test('support nested $ref schema : simple test', async (t) => {
 
 test('support nested $ref schema : complex case', async (t) => {
   const fastify = Fastify()
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'schemaA', type: 'object', properties: { id: { type: 'integer' } } })
     instance.addSchema({ $id: 'schemaB', type: 'object', properties: { id: { type: 'string' } } })
@@ -119,7 +119,7 @@ test('support nested $ref schema : complex case', async (t) => {
 test('support $ref in response schema', async (t) => {
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
   fastify.register(function (instance, _, done) {
     instance.addSchema({ $id: 'order', type: 'string', enum: ['foo'] })
     instance.post('/', { schema: { response: { 200: { type: 'object', properties: { order: { $ref: 'order' } } } } } }, () => {})
@@ -167,7 +167,7 @@ test('support $ref for enums in other schemas', async (t) => {
 
 test('support nested $ref schema : complex case without modifying buildLocalReference', async (t) => {
   const fastify = Fastify()
-  fastify.register(fastifySwagger, { openapi: {} })
+  await fastify.register(fastifySwagger, { openapi: {} })
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'schemaA', type: 'object', properties: { id: { type: 'integer' } } })
     instance.addSchema({ $id: 'schemaB', type: 'object', properties: { id: { type: 'string' } } })

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -21,11 +21,11 @@ const {
   schemaOperationId
 } = require('../../../examples/options')
 
-test('openapi should return a valid swagger object', t => {
-  t.plan(3)
+test('openapi should return a valid swagger object', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -36,27 +36,20 @@ test('openapi should return a valid swagger object', t => {
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
 })
 
-test('openapi should return a valid swagger yaml', t => {
-  t.plan(3)
+test('openapi should return a valid swagger yaml', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -67,26 +60,19 @@ test('openapi should return a valid swagger yaml', t => {
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const swaggerYaml = fastify.swagger({ yaml: true })
-    t.equal(typeof swaggerYaml, 'string')
-
-    try {
-      yaml.load(swaggerYaml)
-      t.pass('valid swagger yaml')
-    } catch (err) {
-      t.fail(err)
-    }
-  })
+  const swaggerYaml = fastify.swagger({ yaml: true })
+  t.equal(typeof swaggerYaml, 'string')
+  yaml.load(swaggerYaml)
+  t.pass('valid swagger yaml')
 })
 
-test('route options - deprecated', t => {
-  t.plan(3)
+test('route options - deprecated', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -106,28 +92,22 @@ test('route options - deprecated', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(openapiObject.paths['/'])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const openapiObject = fastify.swagger()
+
+  await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+  t.ok(openapiObject.paths['/'])
 })
 
-test('route options - meta', t => {
-  t.plan(8)
+test('route options - meta', async (t) => {
+  t.plan(7)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const opts = {
     schema: {
@@ -149,161 +129,133 @@ test('route options - meta', t => {
 
   fastify.get('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.equal(opts.schema.operationId, definedPath.operationId)
-        t.equal(opts.schema.summary, definedPath.summary)
-        t.same(opts.schema.tags, definedPath.tags)
-        t.equal(opts.schema.description, definedPath.description)
-        t.equal(opts.schema.servers, definedPath.servers)
-        t.equal(opts.schema.externalDocs, definedPath.externalDocs)
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const openapiObject = fastify.swagger()
+
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.equal(opts.schema.operationId, definedPath.operationId)
+  t.equal(opts.schema.summary, definedPath.summary)
+  t.same(opts.schema.tags, definedPath.tags)
+  t.equal(opts.schema.description, definedPath.description)
+  t.equal(opts.schema.servers, definedPath.servers)
+  t.equal(opts.schema.externalDocs, definedPath.externalDocs)
 })
 
-test('route options - produces', t => {
-  t.plan(3)
+test('route options - produces', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', schemaProduces, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.responses[200].content, {
-          '*/*': {
-            schema: {
-              type: 'object',
-              properties: {
-                hello: {
-                  description: 'hello',
-                  type: 'string'
-                }
-              },
-              required: ['hello']
-            }
+  const openapiObject = fastify.swagger()
+
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath.responses[200].content, {
+    '*/*': {
+      schema: {
+        type: 'object',
+        properties: {
+          hello: {
+            description: 'hello',
+            type: 'string'
           }
-        })
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
+        },
+        required: ['hello']
+      }
+    }
+
   })
 })
 
-test('route options - cookies', t => {
-  t.plan(3)
+test('route options - cookies', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', schemaCookies, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [
-          {
-            required: false,
-            in: 'cookie',
-            name: 'bar',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [
+    {
+      required: false,
+      in: 'cookie',
+      name: 'bar',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
 })
 
-test('route options - extension', t => {
-  t.plan(5)
+test('route options - extension', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, { openapi: { 'x-ternal': true } })
+  await fastify.register(fastifySwagger, { openapi: { 'x-ternal': true } })
   fastify.get('/', schemaExtension, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.ok(api['x-ternal'])
-        t.same(api['x-ternal'], true)
+  const openapiObject = fastify.swagger()
 
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath['x-tension'], true)
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const api = await Swagger.validate(openapiObject)
+  t.ok(api['x-ternal'])
+  t.same(api['x-ternal'], true)
+
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath['x-tension'], true)
 })
 
-test('parses form parameters when all api consumes application/x-www-form-urlencoded', t => {
-  t.plan(3)
+test('parses form parameters when all api consumes application/x-www-form-urlencoded', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, openapiOption)
-  fastify.get('/', schemaConsumes, () => {})
+  await fastify.register(fastifySwagger, openapiOption)
+  fastify.post('/', schemaConsumes, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.requestBody.content, {
-          'application/x-www-form-urlencoded': {
-            schema: {
-              type: 'object',
-              properties: {
-                hello: {
-                  description: 'hello',
-                  type: 'string'
-                }
-              },
-              required: ['hello']
-            }
+  const openapiObject = fastify.swagger()
+
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].post
+  t.ok(definedPath)
+  t.same(definedPath.requestBody.content, {
+    'application/x-www-form-urlencoded': {
+      schema: {
+        type: 'object',
+        properties: {
+          hello: {
+            description: 'hello',
+            type: 'string'
           }
-        })
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
+        },
+        required: ['hello']
+      }
+    }
+
   })
 })
 
-test('route options - method', t => {
-  t.plan(3)
+test('route options - method', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.route({
     method: ['GET', 'POST'],
@@ -313,27 +265,20 @@ test('route options - method', t => {
     }
   })
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
 })
 
-test('cookie, query, path description', t => {
-  t.plan(7)
+test('cookie, query, path description', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const schemaCookies = {
     schema: {
@@ -371,62 +316,65 @@ test('cookie, query, path description', t => {
   fastify.get('/example', schemaQuerystring, () => {})
   fastify.get('/parameters/:id', schemaParams, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const cookiesPath = api.paths['/'].get
-        t.ok(cookiesPath)
-        t.same(cookiesPath.parameters, [
-          {
-            required: false,
-            in: 'cookie',
-            name: 'bar',
-            description: 'Bar',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-        const querystringPath = api.paths['/example'].get
-        t.ok(querystringPath)
-        t.same(querystringPath.parameters, [
-          {
-            required: false,
-            in: 'query',
-            name: 'hello',
-            description: 'Hello',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-        const paramPath = api.paths['/parameters/{id}'].get
-        t.ok(paramPath)
-        t.same(paramPath.parameters, [
-          {
-            required: true,
-            in: 'path',
-            name: 'id',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+  const cookiesPath = api.paths['/'].get
+  t.ok(cookiesPath)
+  t.same(cookiesPath.parameters, [
+    {
+      required: false,
+      in: 'cookie',
+      name: 'bar',
+      description: 'Bar',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
+  const querystringPath = api.paths['/example'].get
+  t.ok(querystringPath)
+  t.same(querystringPath.parameters, [
+    {
+      required: false,
+      in: 'query',
+      name: 'hello',
+      description: 'Hello',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
+  const paramPath = api.paths['/parameters/{id}'].get
+  t.ok(paramPath)
+  t.same(paramPath.parameters, [
+    {
+      required: true,
+      in: 'path',
+      name: 'id',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
 })
 
 test('cookie and query with serialization type', async (t) => {
   t.plan(4)
-  const fastify = Fastify()
+  const fastify = Fastify({
+    ajv: {
+      plugins: [
+        function (ajv) {
+          ajv.addKeyword({
+            keyword: 'x-consume'
+          })
+        }
+      ]
+    }
+  })
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   const schemaCookies = {
     schema: {
@@ -518,35 +466,28 @@ test('cookie and query with serialization type', async (t) => {
   ])
 })
 
-test('openapi should pass through operationId', t => {
-  t.plan(3)
+test('openapi should pass through operationId', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/hello', schemaOperationId, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
 })
 
-test('openapi should pass through Links', t => {
-  t.plan(4)
+test('openapi should pass through Links', async (t) => {
+  t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/user/:id', {
     schema: {
@@ -605,35 +546,29 @@ test('openapi should pass through Links', t => {
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.same(api.paths['/user/{id}'].get.responses['200'].links, {
-          address: {
-            operationId: 'getUserAddress',
-            parameters: {
-              id: '$request.path.id'
-            }
-          }
-        })
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
+  const api = await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+  t.same(api.paths['/user/{id}'].get.responses['200'].links, {
+    address: {
+      operationId: 'getUserAddress',
+      parameters: {
+        id: '$request.path.id'
+      }
+    }
+
   })
 })
 
-test('links without status code', t => {
-  t.plan(2)
+test('links without status code', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/user/:id', {
     schema: {
@@ -692,17 +627,16 @@ test('links without status code', t => {
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.throws(() => fastify.swagger(), new Error('missing status code 201 in route /user/:id'))
-  })
+  await fastify.ready()
+
+  t.throws(() => fastify.swagger(), new Error('missing status code 201 in route /user/:id'))
 })
 
-test('security headers ignored when declared in security and securityScheme', t => {
-  t.plan(7)
+test('security headers ignored when declared in security and securityScheme', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/address1/:id', {
     schema: {
@@ -740,31 +674,24 @@ test('security headers ignored when declared in security and securityScheme', t 
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
-      })
-      .catch(function (err) {
-        t.error(err)
-      })
-  })
+  const api = await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
-test('security querystrings ignored when declared in security and securityScheme', t => {
-  t.plan(7)
+test('security querystrings ignored when declared in security and securityScheme', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: {
       components: {
         securitySchemes: {
@@ -817,31 +744,24 @@ test('security querystrings ignored when declared in security and securityScheme
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
-      })
-      .catch(function (err) {
-        t.error(err)
-      })
-  })
+  const api = await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
-test('security cookies ignored when declared in security and securityScheme', t => {
-  t.plan(7)
+test('security cookies ignored when declared in security and securityScheme', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: {
       components: {
         securitySchemes: {
@@ -894,31 +814,24 @@ test('security cookies ignored when declared in security and securityScheme', t 
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    t.equal(typeof openapiObject, 'object')
+  const openapiObject = fastify.swagger()
+  t.equal(typeof openapiObject, 'object')
 
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
-      })
-      .catch(function (err) {
-        t.error(err)
-      })
-  })
+  const api = await Swagger.validate(openapiObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
-test('path params on relative url', t => {
-  t.plan(3)
+test('path params on relative url', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiRelativeOptions)
+  await fastify.register(fastifySwagger, openapiRelativeOptions)
 
   const schemaParams = {
     schema: {
@@ -932,27 +845,20 @@ test('path params on relative url', t => {
   }
   fastify.get('/parameters/:id', schemaParams, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const openapiObject = fastify.swagger()
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const paramPath = api.paths['/parameters/{id}'].get
-        t.ok(paramPath)
-        t.same(paramPath.parameters, [
-          {
-            required: true,
-            in: 'path',
-            name: 'id',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+  const paramPath = api.paths['/parameters/{id}'].get
+  t.ok(paramPath)
+  t.same(paramPath.parameters, [
+    {
+      required: true,
+      in: 'path',
+      name: 'id',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
 })

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -10,36 +10,30 @@ const {
   schemaAllOf
 } = require('../../../examples/options')
 
-test('support - oneOf, anyOf, allOf', t => {
-  t.plan(3)
+test('support - oneOf, anyOf, allOf', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, openapiOption)
+  await fastify.register(fastifySwagger, openapiOption)
 
   fastify.get('/', schemaAllOf, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const openapiObject = fastify.swagger()
-    Swagger.validate(openapiObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [
-          {
-            required: false,
-            in: 'query',
-            name: 'foo',
-            schema: {
-              type: 'string'
-            }
-          }
-        ])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [
+    {
+      required: false,
+      in: 'query',
+      name: 'foo',
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
 })
 
 test('support 2xx response', async t => {
@@ -57,7 +51,7 @@ test('support 2xx response', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -87,7 +81,7 @@ test('support status code 204', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -121,7 +115,7 @@ test('support empty response body for different status than 204', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -168,7 +162,7 @@ test('support response headers', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -202,7 +196,7 @@ test('response: description and x-response-description', async () => {
   test('description without x-response-description doubles as response description', async t => {
     // Given a /description endpoint with only a |description| field in its response schema
     const fastify = Fastify()
-    fastify.register(fastifySwagger, openapiOption)
+    await fastify.register(fastifySwagger, openapiOption)
     fastify.get('/description', {
       schema: {
         response: {
@@ -233,7 +227,7 @@ test('response: description and x-response-description', async () => {
   test('description alongside x-response-description only describes response body', async t => {
     // Given a /x-response-description endpoint that also has a |x-response-description| field in its response schema
     const fastify = Fastify()
-    fastify.register(fastifySwagger, openapiOption)
+    await fastify.register(fastifySwagger, openapiOption)
     fastify.get('/responseDescription', {
       schema: {
         response: {
@@ -277,7 +271,7 @@ test('support default=null', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -302,7 +296,7 @@ test('support global schema reference', async t => {
     required: ['hello']
   }
   const fastify = Fastify()
-  fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
+  await fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
   fastify.addSchema({ ...schema, $id: 'requiredUniqueSchema' })
   fastify.get('/', { schema: { query: { $ref: 'requiredUniqueSchema' } } }, () => {})
   await fastify.ready()
@@ -322,7 +316,7 @@ test('support global schema reference with title', async t => {
     required: ['hello']
   }
   const fastify = Fastify()
-  fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
+  await fastify.register(fastifySwagger, { openapi: true, routePrefix: '/docs', exposeRoute: true })
   fastify.addSchema({ ...schema, $id: 'requiredUniqueSchema' })
   fastify.get('/', { schema: { query: { $ref: 'requiredUniqueSchema' } } }, () => {})
   await fastify.ready()
@@ -359,7 +353,7 @@ test('support "default" parameter', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -401,7 +395,7 @@ test('fluent-json-schema', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -441,7 +435,7 @@ test('support "patternProperties" parameter', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -501,7 +495,7 @@ test('properly support "patternProperties" parameter', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -557,18 +551,18 @@ test('support "const" keyword', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opt, () => {})
+  fastify.post('/', opt, () => {})
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
   t.same(definedPath.requestBody, {
     content: {
       'application/json': {
@@ -609,18 +603,18 @@ test('support object properties named "const"', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opt, () => { })
+  fastify.post('/', opt, () => { })
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
   t.same(definedPath.requestBody, {
     content: {
       'application/json': {
@@ -670,18 +664,18 @@ test('support object properties with special names', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opt, () => { })
+  fastify.post('/', opt, () => { })
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
   t.same(definedPath.requestBody, {
     content: {
       'application/json': {
@@ -726,8 +720,17 @@ test('support query serialization params', async t => {
     }
   }
 
-  const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  const fastify = Fastify({
+    ajv: {
+      plugins: [
+        function (ajv) {
+          ajv.addKeyword({ keyword: 'style' })
+          ajv.addKeyword({ keyword: 'explode' })
+        }
+      ]
+    }
+  })
+  await fastify.register(fastifySwagger, {
     openapi: true,
     routePrefix: '/docs',
     exposeRoute: true

--- a/test/spec/swagger/refs.js
+++ b/test/spec/swagger/refs.js
@@ -17,7 +17,7 @@ test('support $ref schema', async t => {
     }
   })
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -75,7 +75,7 @@ test('support nested $ref schema : complex case', async (t) => {
     }
   }
   const fastify = Fastify()
-  fastify.register(fastifySwagger, options)
+  await fastify.register(fastifySwagger, options)
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'schemaA', type: 'object', properties: { id: { type: 'integer' } } })
     instance.addSchema({ $id: 'schemaB', type: 'object', properties: { id: { type: 'string' } } })
@@ -102,7 +102,7 @@ test('support nested $ref schema : complex case', async (t) => {
 
 test('support nested $ref schema : complex case without modifying buildLocalReference', async (t) => {
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -17,11 +17,11 @@ const {
   schemaSecurity
 } = require('../../../examples/options')
 
-test('swagger should return valid swagger object', t => {
-  t.plan(3)
+test('swagger should return valid swagger object', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -32,27 +32,20 @@ test('swagger should return valid swagger object', t => {
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const swaggerObject = fastify.swagger()
-    t.equal(typeof swaggerObject, 'object')
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
 })
 
-test('swagger should return a valid swagger yaml', t => {
-  t.plan(3)
+test('swagger should return a valid swagger yaml', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -63,26 +56,19 @@ test('swagger should return a valid swagger yaml', t => {
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const swaggerYaml = fastify.swagger({ yaml: true })
-    t.equal(typeof swaggerYaml, 'string')
-
-    try {
-      yaml.load(swaggerYaml)
-      t.pass('valid swagger yaml')
-    } catch (err) {
-      t.fail(err)
-    }
-  })
+  const swaggerYaml = fastify.swagger({ yaml: true })
+  t.equal(typeof swaggerYaml, 'string')
+  yaml.load(swaggerYaml)
+  t.pass('valid swagger yaml')
 })
 
-test('route options - deprecated', t => {
-  t.plan(3)
+test('route options - deprecated', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   const opts = {
     schema: {
@@ -102,28 +88,22 @@ test('route options - deprecated', t => {
     }
   }
 
-  fastify.get('/', opts, () => {})
+  fastify.post('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(swaggerObject.paths['/'])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const swaggerObject = fastify.swagger()
+
+  await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(swaggerObject.paths['/'])
 })
 
-test('route options - meta', t => {
-  t.plan(9)
+test('route options - meta', async (t) => {
+  t.plan(8)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   const opts = {
     schema: {
@@ -142,83 +122,65 @@ test('route options - meta', t => {
 
   fastify.get('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.equal(opts.schema.operationId, definedPath.operationId)
-        t.equal(opts.schema.summary, definedPath.summary)
-        t.same(opts.schema.tags, definedPath.tags)
-        t.equal(opts.schema.description, definedPath.description)
-        t.same(opts.schema.produces, definedPath.produces)
-        t.same(opts.schema.consumes, definedPath.consumes)
-        t.equal(opts.schema.externalDocs, definedPath.externalDocs)
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const swaggerObject = fastify.swagger()
+
+  const api = await Swagger.validate(swaggerObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.equal(opts.schema.operationId, definedPath.operationId)
+  t.equal(opts.schema.summary, definedPath.summary)
+  t.same(opts.schema.tags, definedPath.tags)
+  t.equal(opts.schema.description, definedPath.description)
+  t.same(opts.schema.produces, definedPath.produces)
+  t.same(opts.schema.consumes, definedPath.consumes)
+  t.equal(opts.schema.externalDocs, definedPath.externalDocs)
 })
 
-test('route options - consumes', t => {
-  t.plan(3)
+test('route options - consumes', async (t) => {
+  t.plan(2)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
-  fastify.get('/', schemaConsumes, () => {})
+  await fastify.register(fastifySwagger, swaggerOption)
+  fastify.post('/', schemaConsumes, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [{
-          in: 'formData',
-          name: 'hello',
-          description: 'hello',
-          required: true,
-          type: 'string'
-        }])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const swaggerObject = fastify.swagger()
+
+  const api = await Swagger.validate(swaggerObject)
+  const definedPath = api.paths['/'].post
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [{
+    in: 'formData',
+    name: 'hello',
+    description: 'hello',
+    required: true,
+    type: 'string'
+  }])
 })
 
-test('route options - extension', t => {
-  t.plan(5)
+test('route options - extension', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
-  fastify.register(fastifySwagger, { swagger: { 'x-ternal': true } })
+  await fastify.register(fastifySwagger, { swagger: { 'x-ternal': true } })
   fastify.get('/', schemaExtension, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        t.ok(api['x-ternal'])
-        t.same(api['x-ternal'], true)
+  const swaggerObject = fastify.swagger()
 
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath['x-tension'], true)
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const api = await Swagger.validate(swaggerObject)
+  t.ok(api['x-ternal'])
+  t.same(api['x-ternal'], true)
+
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath['x-tension'], true)
 })
 
-test('route options - querystring', t => {
-  t.plan(3)
+test('route options - querystring', async (t) => {
+  t.plan(2)
 
   const opts = {
     schema: {
@@ -234,41 +196,35 @@ test('route options - querystring', t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
   fastify.get('/', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        const definedPath = api.paths['/'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [
-          {
-            in: 'query',
-            name: 'hello',
-            type: 'string',
-            required: true
-          },
-          {
-            in: 'query',
-            name: 'world',
-            type: 'string',
-            required: false,
-            description: 'world description'
-          }
-        ])
-      })
-      .catch(function (err) {
-        t.fail(err)
-      })
-  })
+  const swaggerObject = fastify.swagger()
+
+  const api = await Swagger.validate(swaggerObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [
+    {
+      in: 'query',
+      name: 'hello',
+      type: 'string',
+      required: true
+    },
+    {
+      in: 'query',
+      name: 'world',
+      type: 'string',
+      required: false,
+      description: 'world description'
+    }
+  ])
 })
 
-test('swagger json output should not omit enum part in params config', t => {
-  t.plan(3)
+test('swagger json output should not omit enum part in params config', async (t) => {
+  t.plan(2)
   const opts = {
     schema: {
       params: {
@@ -281,32 +237,27 @@ test('swagger json output should not omit enum part in params config', t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
   fastify.get('/test/:enumKey', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
-    Swagger.validate(swaggerObject)
-      .then((api) => {
-        const definedPath = api.paths['/test/{enumKey}'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [{
-          in: 'path',
-          name: 'enumKey',
-          type: 'string',
-          enum: ['enum1', 'enum2'],
-          required: true
-        }])
-      })
-      .catch(err => {
-        t.error(err)
-      })
-  })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+
+  const api = await Swagger.validate(swaggerObject)
+  const definedPath = api.paths['/test/{enumKey}'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [{
+    in: 'path',
+    name: 'enumKey',
+    type: 'string',
+    enum: ['enum1', 'enum2'],
+    required: true
+  }])
 })
 
-test('custom verbs should not be interpreted as path params', t => {
-  t.plan(3)
+test('custom verbs should not be interpreted as path params', async (t) => {
+  t.plan(2)
   const opts = {
     schema: {
       params: {
@@ -319,36 +270,37 @@ test('custom verbs should not be interpreted as path params', t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
   fastify.get('/resource/:id/sub-resource::watch', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    const swaggerObject = fastify.swagger()
+  await fastify.ready()
 
-    Swagger.validate(swaggerObject)
-      .then((api) => {
-        const definedPath = api.paths['/resource/{id}/sub-resource:watch'].get
-        t.ok(definedPath)
-        t.same(definedPath.parameters, [{
-          in: 'path',
-          name: 'id',
-          type: 'string',
-          required: true
-        }])
-      })
-      .catch(err => {
-        console.log(err)
-        t.error(err)
-      })
-  })
+  const swaggerObject = fastify.swagger()
+
+  const api = await Swagger.validate(swaggerObject)
+  const definedPath = api.paths['/resource/{id}/sub-resource:watch'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [{
+    in: 'path',
+    name: 'id',
+    type: 'string',
+    required: true
+  }])
 })
 
 test('swagger json output should not omit consume in querystring schema', async (t) => {
   t.plan(1)
-  const fastify = Fastify()
+  const fastify = Fastify({
+    ajv: {
+      plugins: [
+        function (ajv) {
+          ajv.addKeyword({ keyword: 'x-consume' })
+        }
+      ]
+    }
+  })
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   const schemaQuerystring = {
     schema: {
@@ -385,11 +337,11 @@ test('swagger json output should not omit consume in querystring schema', async 
   }
 })
 
-test('swagger should not support Links', t => {
-  t.plan(2)
+test('swagger should not support Links', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/user/:id', {
     schema: {
@@ -448,18 +400,16 @@ test('swagger should not support Links', t => {
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    t.throws(() => fastify.swagger(), new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see @fastify/swagger readme)'))
-  })
+  t.throws(() => fastify.swagger(), new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see @fastify/swagger readme)'))
 })
 
-test('security headers ignored when declared in security and securityScheme', t => {
-  t.plan(7)
+test('security headers ignored when declared in security and securityScheme', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwagger, swaggerOption)
 
   fastify.get('/address1/:id', {
     schema: {
@@ -509,31 +459,24 @@ test('security headers ignored when declared in security and securityScheme', t 
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const swaggerObject = fastify.swagger()
-    t.equal(typeof swaggerObject, 'object')
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
-        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
-      })
-      .catch(function (err) {
-        t.error(err)
-      })
-  })
+  const api = await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
-test('security querystrings ignored when declared in security and securityScheme', t => {
-  t.plan(7)
+test('security querystrings ignored when declared in security and securityScheme', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     swagger: {
       securityDefinitions: {
         apiKey: {
@@ -596,22 +539,15 @@ test('security querystrings ignored when declared in security and securityScheme
     }
   }, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
+  await fastify.ready()
 
-    const swaggerObject = fastify.swagger()
-    t.equal(typeof swaggerObject, 'object')
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
 
-    Swagger.validate(swaggerObject)
-      .then(function (api) {
-        t.pass('valid swagger object')
-        t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'somethingElse')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'somethingElse')))
-        t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
-        t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
-      })
-      .catch(function (err) {
-        t.error(err)
-      })
-  })
+  const api = await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'somethingElse')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'somethingElse')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -25,18 +25,18 @@ test('support file in json schema', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opts7, () => {})
+  fastify.post('/', opts7, () => {})
 
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
   t.ok(definedPath)
   t.same(definedPath.parameters, [{
     in: 'formData',
@@ -60,7 +60,7 @@ test('support response description', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -87,7 +87,7 @@ test('response default description', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -114,7 +114,7 @@ test('response 2xx', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -147,7 +147,7 @@ test('response conflict 2xx and 200', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -176,7 +176,7 @@ test('support status code 204', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -209,7 +209,7 @@ test('support empty response body for different status than 204', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -253,7 +253,7 @@ test('support response headers', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -276,7 +276,7 @@ test('response: description and x-response-description', async () => {
   test('description without x-response-description doubles as response description', async t => {
     // Given a /description endpoint with only a |description| field in its response schema
     const fastify = Fastify()
-    fastify.register(fastifySwagger, {
+    await fastify.register(fastifySwagger, {
       routePrefix: '/docs',
       exposeRoute: true
     })
@@ -306,7 +306,7 @@ test('response: description and x-response-description', async () => {
   test('description alongside x-response-description only describes response body', async t => {
     // Given a /responseDescription endpoint that also has a |'x-response-description'| field in its response schema
     const fastify = Fastify()
-    fastify.register(fastifySwagger, {
+    await fastify.register(fastifySwagger, {
       routePrefix: '/docs',
       exposeRoute: true
     })
@@ -363,7 +363,7 @@ test('support "default" parameter', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
@@ -400,7 +400,7 @@ test('fluent-json-schema', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     swagger: true,
     routePrefix: '/docs',
     exposeRoute: true
@@ -448,19 +448,19 @@ test('support "patternProperties" in json schema', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     swagger: true,
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opt, () => {})
+  fastify.post('/', opt, () => {})
 
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
 
   t.same(definedPath.parameters[0].schema, {
     type: 'object',
@@ -500,17 +500,17 @@ test('support "const" keyword', async t => {
   }
 
   const fastify = Fastify()
-  fastify.register(fastifySwagger, {
+  await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
     exposeRoute: true
   })
-  fastify.get('/', opt, () => {})
+  fastify.post('/', opt, () => {})
   await fastify.ready()
 
   const swaggerObject = fastify.swagger()
   const api = await Swagger.validate(swaggerObject)
 
-  const definedPath = api.paths['/'].get
+  const definedPath = api.paths['/'].post
   t.same(definedPath.parameters[0].schema, {
     type: 'object',
     properties: {

--- a/test/transform.js
+++ b/test/transform.js
@@ -30,31 +30,29 @@ const valid = {
 const invalid = {
   transform: 'wrong type'
 }
-test('transform should fail with a value other than Function', t => {
-  t.plan(2)
+
+test('transform should fail with a value other than Function', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, invalid)
+  await fastify.register(fastifySwagger, invalid)
 
   fastify.setValidatorCompiler(({ schema }) => params.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.throws(fastify.swagger)
-  })
+  await fastify.ready()
+  t.throws(fastify.swagger)
 })
-test('transform should work with a Function', t => {
-  t.plan(2)
+
+test('transform should work with a Function', async (t) => {
+  t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fastifySwagger, valid)
+  await fastify.register(fastifySwagger, valid)
 
   fastify.setValidatorCompiler(({ schema }) => params.validate(schema))
   fastify.get('/example', opts, () => {})
 
-  fastify.ready(err => {
-    t.error(err)
-    t.doesNotThrow(fastify.swagger)
-  })
+  await fastify.ready()
+  t.doesNotThrow(fastify.swagger)
 })

--- a/test/util.js
+++ b/test/util.js
@@ -18,7 +18,7 @@ const cases = [
   ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}']
 ]
 
-test('formatParamUrl', t => {
+test('formatParamUrl', async (t) => {
   t.plan(cases.length)
 
   for (const kase of cases) {


### PR DESCRIPTION
`@fastify/swagger` now require to `await` in order to inspect the `routes`.
We skip `HEAD` route as it duplicate of any added `GET` route.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
