### PR TITLE
fix: allow openapi version to be overridden

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -36,7 +36,7 @@ function prepareDefaultOptions (opts) {
     transform,
     hiddenTag,
     extensions,
-    hideUntagged,
+    hideUntagged
   }
 }
 

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -25,6 +25,7 @@ function prepareDefaultOptions (opts) {
   }
 
   return {
+    ...openapi,
     info,
     servers,
     components,
@@ -35,7 +36,7 @@ function prepareDefaultOptions (opts) {
     transform,
     hiddenTag,
     extensions,
-    hideUntagged
+    hideUntagged,
   }
 }
 
@@ -51,6 +52,7 @@ function prepareOpenapiObject (opts) {
     paths: {}
   }
 
+  if (opts.openapi) openapiObject.openapi = opts.openapi
   if (opts.info) openapiObject.info = opts.info
   if (opts.servers) openapiObject.servers = opts.servers
   if (opts.components) openapiObject.components = Object.assign({}, opts.components, { schemas: Object.assign({}, opts.components.schemas) })

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -20,6 +20,18 @@ test('openapi should have default version', async (t) => {
   t.equal(openapiObject.openapi, '3.0.3')
 })
 
+test('openapi version can be overridden', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, { openapi: { openapi: '3.1.0' } })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  t.equal(openapiObject.openapi, '3.1.0')
+})
+
 test('openapi should have default info properties', async (t) => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
Fixes #601