### PR TITLE
Move example and examples object to media (Fix #535)

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -214,9 +214,20 @@ function resolveBodyParams (body, schema, consumes, ref) {
   }
 
   consumes.forEach((consume) => {
-    body.content[consume] = {
-      schema: resolved
+    // examples and example fields should be on the top level of the media object
+    const mediaObject = { schema: resolved }
+    if (resolved.examples) {
+      mediaObject.examples = resolved.examples
+
+      // examples is invalid property of media object schema
+      delete resolved.examples
     }
+
+    if (resolved.example) {
+      mediaObject.example = resolved.example
+    }
+
+    body.content[consume] = mediaObject
   })
   if (resolved && resolved.required && resolved.required.length) {
     body.required = true

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -393,6 +393,78 @@ test('transforms examples in example if single object example', async (t) => {
   t.same(schema.properties.hello.example, { lorem: 'ipsum' })
 })
 
+test('copy example from component to media', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  const body = {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    },
+    examples: [{ hello: 'world' }]
+  }
+
+  const opts = {
+    schema: {
+      body
+    }
+  }
+
+  fastify.post('/', opts, () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const content = openapiObject.paths['/'].post.requestBody.content['application/json']
+  const schema = content.schema
+
+  t.ok(schema)
+  t.ok(schema.properties)
+  t.same(schema.example, { hello: 'world' })
+  t.same(content.example, { hello: 'world' })
+})
+
+test('move examples from component to media', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  const body = {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    },
+    examples: [{ hello: 'world' }, { hello: 'lorem' }]
+  }
+
+  const opts = {
+    schema: {
+      body
+    }
+  }
+
+  fastify.post('/', opts, () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const content = openapiObject.paths['/'].post.requestBody.content['application/json']
+  const schema = content.schema
+
+  t.ok(schema)
+  t.ok(schema.properties)
+  t.notOk(schema.examples)
+  t.same(content.examples, { example1: { value: { hello: 'world' } }, example2: { value: { hello: 'lorem' } } })
+})
+
 test('uses examples if has multiple string examples', async (t) => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Hi! Fixes Issue #535 
Moved the example and examples fields to the level above. Now the scheme is valid and displays correctly in swagger.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
