### PR TITLE
Backport #609 to 6.x branch

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -234,7 +234,7 @@ function resolveCommonParams (container, parameters, schema, ref, sharedSchemas,
     resolved = pathParts.reduce((resolved, pathPart) => resolved[pathPart], ref.definitions().definitions)
   }
 
-  const arr = plainJsonObjectToOpenapi3(container, resolved, sharedSchemas, securityIgnores)
+  const arr = plainJsonObjectToOpenapi3(container, resolved, { ...sharedSchemas, ...ref.definitions().definitions }, securityIgnores)
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -184,7 +184,9 @@ function resolveLocalRef (jsonSchema, externalSchemas) {
 
   // $ref is in the format: #/definitions/<resolved definition>/<optional fragment>
   const localRef = jsonSchema.$ref.split('/')[2]
-  return resolveLocalRef(externalSchemas[localRef], externalSchemas)
+  if (externalSchemas[localRef]) return resolveLocalRef(externalSchemas[localRef], externalSchemas)
+  // $ref is in the format: #/components/schemas/<resolved definition>
+  return resolveLocalRef(externalSchemas[jsonSchema.$ref.split('/')[3]], externalSchemas)
 }
 
 function readPackageJson () {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^10.1.0",
     "@types/node": "^17.0.0",
     "fastify": "^3.7.0",
     "fastify-basic-auth": "^2.1.0",
@@ -52,7 +53,6 @@
     "pre-commit": "^1.2.2",
     "qs": "^6.5.2",
     "standard": "^17.0.0",
-    "swagger-parser": "^10.0.2",
     "swagger-ui-dist": "4.6.2",
     "tap": "^16.0.0",
     "tsd": "^0.20.0"

--- a/test/mode/static.js
+++ b/test/mode/static.js
@@ -6,7 +6,7 @@ const Fastify = require('fastify')
 const fastifySwagger = require('../../index')
 const fastifySwaggerDynamic = require('../../lib/mode/dynamic')
 const yaml = require('js-yaml')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 
 const resolve = require('path').resolve
 const readFileSync = require('fs').readFileSync

--- a/test/route.js
+++ b/test/route.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const yaml = require('js-yaml')
 const fastifySwagger = require('../index')
 const {

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const { readPackageJson } = require('../../../lib/util/common')

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const {

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const fastifySwagger = require('../../../index')
 const S = require('fluent-json-schema')
 const {
@@ -40,6 +40,48 @@ test('support - oneOf, anyOf, allOf', t => {
         t.fail(err)
       })
   })
+})
+
+test('support - oneOf, anyOf, allOf in headers', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  const schema = {
+    schema: {
+      headers: {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' }
+            }
+          }
+        ]
+      }
+    }
+  }
+  fastify.get('/', schema, () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+
+  const api = await Swagger.validate(openapiObject)
+  const definedPath = api.paths['/'].get
+  t.ok(definedPath)
+  t.same(definedPath.parameters, [
+    {
+      required: false,
+      in: 'header',
+      name: 'foo',
+      description: undefined,
+      schema: {
+        type: 'string'
+      }
+    }
+  ])
 })
 
 test('support 2xx response', async t => {

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const { readPackageJson } = require('../../../lib/util/common')

--- a/test/spec/swagger/refs.js
+++ b/test/spec/swagger/refs.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const fastifySwagger = require('../../../index')
 
 test('support $ref schema', async t => {

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const yaml = require('js-yaml')
 const fastifySwagger = require('../../../index')
 const {

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const Swagger = require('swagger-parser')
+const Swagger = require('@apidevtools/swagger-parser')
 const fastifySwagger = require('../../../index')
 const S = require('fluent-json-schema')
 


### PR DESCRIPTION
Backport the #609 PR to 6.x branch as it also affects Fastify v3
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
