### PR TITLE
feat: update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 A Fastify plugin for serving a [Swagger UI](https://swagger.io/tools/swagger-ui/), using [Swagger (OpenAPI v2)](https://swagger.io/specification/v2/) or [OpenAPI v3](https://swagger.io/specification) schemas automatically generated from your route schemas, or from an existing Swagger/OpenAPI schema.
 
-Supports Fastify versions `>=3.0.0`. For `fastify@2`, please refer to [`branch@2.x`](https://github.com/fastify/fastify-swagger/tree/2.x) and for `fastify@1.9`, please refer to [`branch@1.x`](https://github.com/fastify/fastify-swagger/tree/1.x).
+Supports Fastify versions `4.x`.
+
+- Please refer to [6.x](https://github.com/fastify/fastify-swagger/tree/6.x) for Fastify `^3.x` compatibility.
+- Please refer to [3.x](https://github.com/fastify/fastify-swagger/tree/2.x) for Fastify `^2.x` compatibility.
+- Please refer to [1.x](https://github.com/fastify/fastify-swagger/tree/1.x) for Fastify `^1.x` compatibility.
 
 If you are looking for a plugin to generate routes from an existing OpenAPI schema, check out [fastify-openapi-glue](https://github.com/seriousme/fastify-openapi-glue).
 


### PR DESCRIPTION
This pull request has the goal to update the docs because they does not say that the current version of `fastify-swagger` does not support fastify v3. [Issue related](https://github.com/fastify/fastify-swagger/issues/624). The writing is based on the `fastify-cors` [docs](https://github.com/fastify/fastify-cors).

Tests output:

```
> @fastify/swagger@7.4.1 test
> npm run prepare && npm run coverage && npm run typescript 


> @fastify/swagger@7.4.1 prepare
> node lib/util/prepare-swagger-ui


> @fastify/swagger@7.4.1 coverage
> npm run unit -- --coverage-report=lcovonly


> @fastify/swagger@7.4.1 unit
> tap -J "test/**/*.js" "--coverage-report=lcovonly"

 PASS ​ test/decorator.js 2 OK 821.445ms
 PASS ​ test/integration.js 1 OK 1s
 PASS ​ test/transform.js 2 OK 764.111ms
 PASS ​ test/esm/index.test.js 1 OK 815.311ms
 PASS ​ test/hooks.js 17 OK 1s                              
 PASS ​ test/spec/swagger/option.js 31 OK 1s
 PASS ​ test/mode/static.js 80 OK 1s
 PASS ​ test/csp.js 30 OK 1s                                
 PASS ​ test/util.js 12 OK 12.149ms
 PASS ​ test/spec/openapi/option.js 77 OK 1s
 PASS ​ test/spec/swagger/refs.js 11 OK 2s
 PASS ​ test/route.js 56 OK 2s                              
 PASS ​ test/spec/openapi/refs.js 27 OK 2s
 PASS ​ test/spec/swagger/route.js 40 OK 2s
 PASS ​ test/spec/swagger/schema.js 31 OK 2s
 PASS ​ test/spec/openapi/route.js 61 OK 3s
 PASS ​ test/spec/openapi/schema.js 37 OK 3s


                                                           
  🌈 SUMMARY RESULTS 🌈                                    
                                                           

Suites:   ​17 passed​, ​17 of 17 completed​
Asserts:  ​​​516 passed​, ​of 516​                               
Time:​   ​5s​
```

**There is no `benchmark` script.**

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
