### PR TITLE
chore(prepare-swagger-ui): make regex case-insensitive

### DIFF
--- a/lib/util/prepare-swagger-ui.js
+++ b/lib/util/prepare-swagger-ui.js
@@ -79,8 +79,8 @@ const sha = {
   style: []
 }
 function computeCSPHashes (path) {
-  const scriptRegex = /<script>(.*)<\/script>/gs
-  const styleRegex = /<style>(.*)<\/style>/gs
+  const scriptRegex = /<script>(.*)<\/script>/gis
+  const styleRegex = /<style>(.*)<\/style>/gis
   const indexSrc = fs.readFileSync(resolve(path)).toString('utf8')
   let result = scriptRegex.exec(indexSrc)
   while (result !== null) {


### PR DESCRIPTION
The regex is used to evaluate and alter contents of `swagger-ui-dist`, that we have no control over.
They may decide to go all caps for some reason, so this provides a safeguard against that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
