### PR TITLE
replace js-yaml with yaml

### DIFF
--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const fs = require('fs')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 
 module.exports = function (fastify, opts, done) {
   if (!opts.specification) return done(new Error('specification is missing in the module options'))
@@ -39,7 +39,7 @@ module.exports = function (fastify, opts, done) {
     )
     switch (extName) {
       case '.yaml':
-        swaggerObject = yaml.load(source)
+        swaggerObject = yaml.parse(source)
         break
       case '.json':
         swaggerObject = JSON.parse(source)
@@ -85,7 +85,7 @@ module.exports = function (fastify, opts, done) {
     }
 
     if (opts && opts.yaml) {
-      const swaggerString = yaml.dump(swaggerObject, { skipInvalid: true })
+      const swaggerString = yaml.stringify(swaggerObject, { strict: false })
       cache.swaggerString = swaggerString
       return swaggerString
     }

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const { shouldRouteHide } = require('../../util/common')
 const { prepareDefaultOptions, prepareOpenapiObject, prepareOpenapiMethod, prepareOpenapiSchemas, normalizeUrl } = require('./utils')
 
@@ -65,7 +65,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
     }
 
     if (opts && opts.yaml) {
-      cache.string = yaml.dump(openapiObject, { skipInvalid: true })
+      cache.string = yaml.stringify(openapiObject, { strict: false })
       return cache.string
     }
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const { shouldRouteHide } = require('../../util/common')
 const { prepareDefaultOptions, prepareSwaggerObject, prepareSwaggerMethod, normalizeUrl, prepareSwaggerDefinitions } = require('./utils')
 
@@ -60,7 +60,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
     }
 
     if (opts && opts.yaml) {
-      cache.string = yaml.dump(swaggerObject, { skipInvalid: true })
+      cache.string = yaml.stringify(swaggerObject, { strict: false })
       return cache.string
     }
 

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
   "dependencies": {
     "@fastify/static": "^6.0.0",
     "fastify-plugin": "^4.0.0",
-    "js-yaml": "^4.1.0",
     "json-schema-resolver": "^1.3.0",
     "openapi-types": "^12.0.0",
-    "rfdc": "^1.3.0"
+    "rfdc": "^1.3.0",
+    "yaml": "^2.1.1"
   },
   "standard": {
     "ignore": [

--- a/tap-snapshots/test/mode/static.js.test.cjs
+++ b/tap-snapshots/test/mode/static.js.test.cjs
@@ -23,7 +23,7 @@ paths:
       tags:
         - Status
       responses:
-        '200':
+        "200":
           description: Server is alive
           content:
             application/json:
@@ -36,7 +36,7 @@ paths:
                     type: string
                 example:
                   health: true
-                  date: '2018-02-19T15:36:46.758Z'
+                  date: 2018-02-19T15:36:46.758Z
 
 `
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 
 const fastifySwagger = require('../index')
 const { swaggerOption, schemaBody } = require('../examples/options')
@@ -49,7 +49,7 @@ test('hooks on static swagger', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['content-type'], 'application/x-yaml')
   try {
-    yaml.load(res.payload)
+    yaml.parse(res.payload)
     t.pass('valid swagger yaml')
   } catch (err) {
     t.fail(err)
@@ -65,7 +65,7 @@ test('hooks on static swagger', async t => {
   t.equal(typeof res.payload, 'string')
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   try {
-    yaml.load(res.payload)
+    yaml.parse(res.payload)
     t.pass('valid swagger json')
   } catch (err) {
     t.fail(err)

--- a/test/route.js
+++ b/test/route.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('fastify')
 const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const fastifySwagger = require('../index')
 const {
   schemaQuerystring,
@@ -164,7 +164,7 @@ test('fastify.swagger should return a valid swagger yaml', async (t) => {
 
   t.equal(typeof res.payload, 'string')
   t.equal(res.headers['content-type'], 'application/x-yaml')
-  yaml.load(res.payload)
+  yaml.parse(res.payload)
   t.pass('valid swagger yaml')
 })
 

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const fastifySwagger = require('../../../index')
 const { readPackageJson } = require('../../../lib/util/common')
 const { openapiOption } = require('../../../examples/options')
@@ -318,7 +318,7 @@ test('cache - yaml', async (t) => {
   fastify.swagger({ yaml: true })
   const swaggerYaml = fastify.swagger({ yaml: true })
   t.equal(typeof swaggerYaml, 'string')
-  yaml.load(swaggerYaml)
+  yaml.parse(swaggerYaml)
   t.pass('valid swagger yaml')
 })
 

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const fastifySwagger = require('../../../index')
 const {
   openapiOption,
@@ -64,7 +64,7 @@ test('openapi should return a valid swagger yaml', async (t) => {
 
   const swaggerYaml = fastify.swagger({ yaml: true })
   t.equal(typeof swaggerYaml, 'string')
-  yaml.load(swaggerYaml)
+  yaml.parse(swaggerYaml)
   t.pass('valid swagger yaml')
 })
 

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const fastifySwagger = require('../../../index')
 const { readPackageJson } = require('../../../lib/util/common')
 const { swaggerOption } = require('../../../examples/options')
@@ -415,7 +415,7 @@ test('cache - yaml', async (t) => {
   fastify.swagger({ yaml: true })
   const swaggerYaml = fastify.swagger({ yaml: true })
   t.equal(typeof swaggerYaml, 'string')
-  yaml.load(swaggerYaml)
+  yaml.parse(swaggerYaml)
   t.pass('valid swagger yaml')
 })
 

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('js-yaml')
+const yaml = require('yaml')
 const fastifySwagger = require('../../../index')
 const {
   swaggerOption,
@@ -60,7 +60,7 @@ test('swagger should return a valid swagger yaml', async (t) => {
 
   const swaggerYaml = fastify.swagger({ yaml: true })
   t.equal(typeof swaggerYaml, 'string')
-  yaml.load(swaggerYaml)
+  yaml.parse(swaggerYaml)
   t.pass('valid swagger yaml')
 })
 


### PR DESCRIPTION
https://github.com/fastify/fastify-swagger/pull/644#issuecomment-1202966258

I did not run any benchmarks. And it seems that the strings were using double quotes and Dates are outputted without quotes at all, which seems to be correct.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
