### PR TITLE
add swagger-ui vendor extensions, esp. x-tokenName

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,23 @@
 import {FastifyPluginCallback, FastifySchema, onRequestHookHandler, preHandlerHookHandler} from 'fastify';
 import { OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 
+/**
+ * Swagger-UI Vendor Extensions
+ * @see https://support.smartbear.com/swaggerhub/docs/apis/vendor-extensions.html#api-docs-x-tokenname
+ */
+declare module 'openapi-types' {
+  namespace OpenAPIV3 {
+    interface OAuth2SecurityScheme {
+      'x-tokenName'?: string;
+    }
+  }
+  namespace OpenAPIV2 {
+    interface SecuritySchemeOauth2Base {
+      'x-tokenName'?: string;
+    }
+  }
+}
+
 declare module 'fastify' {
   interface FastifyInstance {
     swagger: (

--- a/test/types/swagger-ui-vendor-extensions.test.ts
+++ b/test/types/swagger-ui-vendor-extensions.test.ts
@@ -1,0 +1,112 @@
+import { OpenAPIV2, OpenAPIV3 } from 'openapi-types'
+
+const xTokenNameOpenAPIv3: OpenAPIV3.Document = {
+  openapi: '3.0.0',
+  info: {
+    'version': '1.0.0',
+    'title': 'Test OpenApiv3 specification',
+  },
+  components: {
+    securitySchemes: {
+      myAuth: {
+        type: 'oauth2',
+        'x-tokenName': 'id_token',
+        flows: {
+          implicit: {
+            authorizationUrl: `http.../login/oauth/authorize`,
+            scopes: {},
+          },
+        },
+      },
+    }
+  },
+  paths: {}
+}
+
+const xTokenNameOpenAPIv2: OpenAPIV2.Document = {
+  swagger: '2.0.0',
+  info: {
+    title: 'Test OpenApiv2 specification',
+    version: '2.0.0'
+  },
+  securityDefinitions: {
+    OAuth2AccessCodeFlow: {
+      type: "oauth2",
+      flow: "accessCode",
+      authorizationUrl: "https://example.com/oauth/authorize",
+      tokenUrl: "https://example.com/oauth/token",
+      "x-tokenName": 'id_token',
+      scopes: { }
+    },
+    OAuth2ApplicationFlow: {
+      type: "oauth2",
+      flow: "application",
+      tokenUrl: "https://example.com/oauth/token",
+      "x-tokenName": 'id_token',
+      scopes: { }
+    },
+    OAuth2ImplicitFlow: {
+      type: "oauth2",
+      flow: "implicit",
+      authorizationUrl: "https://example.com/oauth/authorize",
+      "x-tokenName": 'id_token',
+      scopes: { }
+    },
+    OAuth2PasswordFlow: {
+      type: "oauth2",
+      flow: "password",
+      tokenUrl: "https://example.com/oauth/token",
+      "x-tokenName": 'id_token',
+      scopes: { }
+    },
+  },
+  paths: {}
+}
+
+const xExampleOpenAPIv2: OpenAPIV2.Document = {
+  swagger: '2.0.0',
+  info: {
+    title: 'Test OpenApiv2 specification',
+    version: '2.0.0'
+  },
+  paths: {
+    "/users/{userId}": {
+      'get': {
+        summary: "Gets a user by ID.",
+        responses: {
+        },
+        parameters: [
+          {
+            in: "path",
+            name: "userId",
+            type: "integer",
+            required: true,
+            description: "Numeric ID of the user to get.",
+            'x-example': 'BADC0FFEE'
+          },
+          {
+            in: "query",
+            name: "offset",
+            type: "integer",
+            description: "The number of items to skip before starting to collect the result set.",
+            'x-example': 1337
+          },
+          {
+            in: "header",
+            name: "X-Request-ID",
+            type: "string",
+            required: true,
+            'x-example': 'wget'
+          },
+          {
+            in: "formData",
+            name: "name",
+            type: "string",
+            description: "A person's name.",
+            'x-example': 'John Doe'
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #654 

This PR adds the swagger ui vendor extensions x-tokenName.

There are two extensions. x-example and x-tokenName.

x-example does not need patching, because it is already covered by openapi-types. But I added typings tests to ensure, that they are possible. Didnt want that somebody comes tomorrow and says, they are missing... ;)

So this adds x-tokenName to the SecuritySchemas of OpenAPI v2 and v3.

ref: https://github.com/swagger-api/swagger-ui/pull/2587 (adding x-tokenName to OpenAPI2 in swagger-ui)
ref: https://github.com/swagger-api/swagger-js/pull/1489 (adding x-tokenName to OpenAPI3 in swagger-ui)

@fernandolguevara 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
