### PR TITLE
avoid crashing of resolveLocalRef

### DIFF
--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -193,6 +193,7 @@ function resolveLocalRef (jsonSchema, externalSchemas) {
     // $ref is in the format: #/components/schemas/<resolved definition>
     return resolveLocalRef(externalSchemas[jsonSchema.$ref.split('/')[3]], externalSchemas)
   }
+  return jsonSchema
 }
 
 function readPackageJson () {

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -187,10 +187,12 @@ function resolveLocalRef (jsonSchema, externalSchemas) {
   }
 
   // $ref is in the format: #/definitions/<resolved definition>/<optional fragment>
-  const localRef = jsonSchema.$ref.split('/')[2]
-  if (externalSchemas[localRef]) return resolveLocalRef(externalSchemas[localRef], externalSchemas)
-  // $ref is in the format: #/components/schemas/<resolved definition>
-  return resolveLocalRef(externalSchemas[jsonSchema.$ref.split('/')[3]], externalSchemas)
+  if (jsonSchema.$ref) {
+    const localRef = jsonSchema.$ref.split('/')[2]
+    if (externalSchemas[localRef]) return resolveLocalRef(externalSchemas[localRef], externalSchemas)
+    // $ref is in the format: #/components/schemas/<resolved definition>
+    return resolveLocalRef(externalSchemas[jsonSchema.$ref.split('/')[3]], externalSchemas)
+  }
 }
 
 function readPackageJson () {


### PR DESCRIPTION
Probably wont fix #634 and #633 because it just avoids the crashing of fastify-swagger. 

I think there is still some underlying issues on generating a proper output. But because we dont get a crash of fastify-swagger, people should report, if the generated schema is correct or not and fix it in a follow up issue/PR

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
