### PR TITLE
feat: allow to define route log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
  | uiConfig            | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
  | uiHooks            | {}               | Additional hooks for the documentation's routes. You can provide the `onRequest` and `preHandler` hooks with the same [route's options](https://www.fastify.io/docs/latest/Routes/#options) interface.|
  | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
+ | logLevel           | info             | Allow to define route log level.                                                                                           |
 
 If you set `exposeRoute` to `true` the plugin will expose the documentation with the following APIs:
 

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -29,13 +29,15 @@ module.exports = function (fastify, opts, done) {
     const initOAuth = opts.initOAuth || {}
     const staticCSP = opts.staticCSP
     const transformStaticCSP = opts.transformStaticCSP
+    const logLevel = opts.logLevel || 'info'
     fastify.register(require('../routes'), {
       prefix,
       uiConfig,
       initOAuth,
       staticCSP,
       transformStaticCSP,
-      hooks: opts.uiHooks
+      hooks: opts.uiHooks,
+      logLevel
     })
   }
 

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -29,7 +29,7 @@ module.exports = function (fastify, opts, done) {
     const initOAuth = opts.initOAuth || {}
     const staticCSP = opts.staticCSP
     const transformStaticCSP = opts.transformStaticCSP
-    const logLevel = opts.logLevel || 'info'
+    const logLevel = opts.logLevel
     fastify.register(require('../routes'), {
       prefix,
       uiConfig,

--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -67,7 +67,7 @@ module.exports = function (fastify, opts, done) {
       staticCSP: opts.staticCSP,
       transformStaticCSP: opts.transformStaticCSP,
       hooks: opts.uiHooks,
-      logLevel: opts.logLevel || 'info'
+      logLevel: opts.logLevel
     }
 
     fastify.register(require('../routes'), options)

--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -66,7 +66,8 @@ module.exports = function (fastify, opts, done) {
       baseDir: opts.specification.baseDir,
       staticCSP: opts.staticCSP,
       transformStaticCSP: opts.transformStaticCSP,
-      hooks: opts.uiHooks
+      hooks: opts.uiHooks,
+      logLevel: opts.logLevel || 'info'
     }
 
     fastify.register(require('../routes'), options)

--- a/test/route.js
+++ b/test/route.js
@@ -541,3 +541,39 @@ test('/documentation/ should redirect to ./static/index.html', async (t) => {
   t.equal(res.statusCode, 302)
   t.equal(res.headers.location, './static/index.html')
 })
+
+test('should return silent log level of route /documentation', async (t) => {
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', function (route) {
+    t.equal(route.logLevel, 'silent')
+  })
+
+  await fastify.register(fastifySwagger, { ...swaggerOption, logLevel: 'silent' })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation'
+  })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(typeof res.payload, 'string')
+})
+
+test('should return empty log level of route /documentation', async (t) => {
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', function (route) {
+    t.equal(route.logLevel, '')
+  })
+
+  await fastify.register(fastifySwagger, swaggerOption)
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation'
+  })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(typeof res.payload, 'string')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

The purpose of this PR is to allow to define a specific log level in scenarios when we want to `silent` all logs of the swagger route.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
