### PR TITLE
docs: remove logLevel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
  | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                              |
  | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                                                                                              |
  | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
- | logLevel           | info             | Allow to define route log level.                                                                                           |
 
 <a name="register.options.transform"></a>
 #### Transform


### PR DESCRIPTION
The proposal of this PR is update docs removing `logLevel` option because now silent log into swagger route is part of `fastify-swagger-ui`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
