### PR TITLE
feat: add support for server relative and templated urls 

### DIFF
--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -2,7 +2,7 @@
 
 const yaml = require('yaml')
 const { shouldRouteHide } = require('../../util/common')
-const { prepareDefaultOptions, prepareOpenapiObject, prepareOpenapiMethod, prepareOpenapiSchemas, normalizeUrl } = require('./utils')
+const { prepareDefaultOptions, prepareOpenapiObject, prepareOpenapiMethod, prepareOpenapiSchemas, normalizeUrl, resolveServerUrls } = require('./utils')
 
 module.exports = function (opts, cache, routes, Ref, done) {
   let ref
@@ -25,6 +25,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       ...(ref.definitions().definitions)
     }, ref)
 
+    const serverUrls = resolveServerUrls(defOpts.servers)
     for (const route of routes) {
       const transformResult = defOpts.transform
         ? defOpts.transform({ schema: route.schema, url: route.url })
@@ -39,7 +40,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       if (shouldRouteHide(schema, shouldRouteHideOpts)) continue
 
       let url = transformResult.url || route.url
-      url = normalizeUrl(url, defOpts.servers, defOpts.stripBasePath)
+      url = normalizeUrl(url, serverUrls, defOpts.stripBasePath)
 
       const openapiRoute = Object.assign({}, openapiObject.paths[url])
 

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -26,6 +26,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
     }, ref)
 
     const serverUrls = resolveServerUrls(defOpts.servers)
+
     for (const route of routes) {
       const transformResult = defOpts.transform
         ? defOpts.transform({ schema: route.schema, url: route.url })

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -68,11 +68,9 @@ function prepareOpenapiObject (opts) {
   return openapiObject
 }
 
-function normalizeUrl (url, servers, stripBasePath) {
+function normalizeUrl (url, serverUrls, stripBasePath) {
   if (!stripBasePath) return formatParamUrl(url)
-  servers = Array.isArray(servers) ? servers : []
-  servers.forEach(function (server) {
-    const serverUrl = resolveUrlVariables(server.url, server.variables)
+  serverUrls.forEach(function (serverUrl) {
     const basePath = serverUrl.startsWith('/') ? serverUrl : new URL(serverUrl).pathname
     if (url.startsWith(basePath) && basePath !== '/') {
       url = url.replace(basePath, '')
@@ -81,18 +79,34 @@ function normalizeUrl (url, servers, stripBasePath) {
   return formatParamUrl(url)
 }
 
-function resolveUrlVariables (url, variables) {
-  const findVariablesRegex = /{(.*?)}/g // As for OpenAPI v3 spec url variables are named in brackets, e.g. {foo}
-  const matches = url.matchAll(findVariablesRegex)
+function resolveServerUrls (servers) {
+  const resolvedUrls = []
 
-  /* _match_ is an array like: [ '{foo}', 'foo', index: <number>, input: <url>, groups: <groups> ] */
-  for (const match of matches) {
-    const variableName = match[0]
-    const variableValue = variables[match[1]]?.default ?? variableName
-    url = url.replace(variableName, variableValue)
+  servers = Array.isArray(servers) ? servers : []
+  for (const server of servers) {
+    const originalUrl = server.url
+    const variables = server.variables
+
+    let url = originalUrl
+    const findVariablesRegex = /{(.*?)}/g // As for OpenAPI v3 spec url variables are named in brackets, e.g. {foo}
+    const matches = url.matchAll(findVariablesRegex)
+
+    for (const match of matches) {
+      const variableNameInBrackets = match[0]
+      const variableName = match[1]
+      const variableValue = variables?.[variableName]?.default
+
+      if (variableValue === undefined) {
+        throw new Error(`Server url ${originalUrl} could not be resolved. Make sure to provide a default value for each url variable.`)
+      }
+
+      url = url.replace(variableNameInBrackets, variableValue)
+    }
+
+    resolvedUrls.push(url)
   }
 
-  return url
+  return resolvedUrls
 }
 
 function transformDefsToComponents (jsonSchema) {
@@ -441,5 +455,6 @@ module.exports = {
   prepareOpenapiObject,
   prepareOpenapiMethod,
   prepareOpenapiSchemas,
+  resolveServerUrls,
   normalizeUrl
 }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -72,12 +72,27 @@ function normalizeUrl (url, servers, stripBasePath) {
   if (!stripBasePath) return formatParamUrl(url)
   servers = Array.isArray(servers) ? servers : []
   servers.forEach(function (server) {
-    const basePath = new URL(server.url).pathname
+    const serverUrl = resolveUrlVariables(server.url, server.variables)
+    const basePath = serverUrl.startsWith('/') ? serverUrl : new URL(serverUrl).pathname
     if (url.startsWith(basePath) && basePath !== '/') {
       url = url.replace(basePath, '')
     }
   })
   return formatParamUrl(url)
+}
+
+function resolveUrlVariables (url, variables) {
+  const findVariablesRegex = /{(.*?)}/g // As for OpenAPI v3 spec url variables are named in brackets, e.g. {foo}
+  const matches = url.matchAll(findVariablesRegex)
+
+  /* _match_ is an array like: [ '{foo}', 'foo', index: <number>, input: <url>, groups: <groups> ] */
+  for (const match of matches) {
+    const variableName = match[0]
+    const variableValue = variables[match[1]]?.default ?? variableName
+    url = url.replace(variableName, variableValue)
+  }
+
+  return url
 }
 
 function transformDefsToComponents (jsonSchema) {

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -95,7 +95,7 @@ function resolveServerUrls (servers) {
       const value = variables?.[name]?.default
 
       if (value === undefined) {
-        throw new Error(`Server url ${originalUrl} could not be resolved. Make sure to provide a default value for each url variable.`)
+        throw new Error(`Server URL ${originalUrl} could not be resolved. Make sure to provide a default value for each URL variable.`)
       }
 
       url = url.replace(nameInBrackets, value)

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -81,6 +81,7 @@ function normalizeUrl (url, serverUrls, stripBasePath) {
 
 function resolveServerUrls (servers) {
   const resolvedUrls = []
+  const findVariablesRegex = /{(.*?)}/g // As for OpenAPI v3 spec url variables are named in brackets, e.g. {foo}
 
   servers = Array.isArray(servers) ? servers : []
   for (const server of servers) {
@@ -88,19 +89,16 @@ function resolveServerUrls (servers) {
     const variables = server.variables
 
     let url = originalUrl
-    const findVariablesRegex = /{(.*?)}/g // As for OpenAPI v3 spec url variables are named in brackets, e.g. {foo}
     const matches = url.matchAll(findVariablesRegex)
 
-    for (const match of matches) {
-      const variableNameInBrackets = match[0]
-      const variableName = match[1]
-      const variableValue = variables?.[variableName]?.default
+    for (const [nameInBrackets, name] of matches) {
+      const value = variables?.[name]?.default
 
-      if (variableValue === undefined) {
+      if (value === undefined) {
         throw new Error(`Server url ${originalUrl} could not be resolved. Make sure to provide a default value for each url variable.`)
       }
 
-      url = url.replace(variableNameInBrackets, variableValue)
+      url = url.replace(nameInBrackets, value)
     }
 
     resolvedUrls.push(url)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` 
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Hello everyone, in an attempt to fix issues #494 and #540 I integrated support for `server` relative and templated urls.

When `stripBasePath` was set to true then the server url was being parsed as is using `new URL(serverUrl)`. This inevitably resulted in an error when the server url was either relative (e.g. `/foo/bar`) or templated (e.g. `http://localhost:{port}/{basePath}`). 

The changes introduced by this PR solve the issue by first resolving the server url (by replacing templated variables with the corresponing values) and then by using it as is if relative or otherwise parsing it through `new URL(serverUrl)` in order to extract the pathname.

Fixes #494, Fixes #540


