### PR TITLE
fix: Pass JSON Schema keywords into OpenAPI Header Spec

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -156,6 +156,7 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, secu
   let toOpenapiProp
   switch (container) {
     case 'cookie':
+    case 'header':
     case 'query':
       toOpenapiProp = function (propertyName, jsonSchemaElement) {
         let result = {
@@ -200,35 +201,6 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, secu
 
         // description should be optional
         if (jsonSchemaElement.description) result.description = jsonSchemaElement.description
-        return result
-      }
-      break
-    case 'header':
-      toOpenapiProp = function (propertyName, jsonSchemaElement) {
-        const { required, description, ...schema } = jsonSchemaElement
-
-        const result = {
-          in: 'header',
-          name: propertyName,
-          required,
-          description,
-          schema
-          // currently not handled, since they are not JSON Schema properties:
-          // style
-          // explode
-          // allowReserved
-          // per media type
-        }
-
-        const media = schemaToMedia(jsonSchemaElement)
-        if (media.example) {
-          result.example = media.example
-        }
-
-        if (media.examples) {
-          result.examples = media.examples
-        }
-
         return result
       }
       break

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -205,14 +205,19 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, secu
       break
     case 'header':
       toOpenapiProp = function (propertyName, jsonSchemaElement) {
+        const { required, description, ...schema } = jsonSchemaElement
+
         const result = {
           in: 'header',
           name: propertyName,
-          required: jsonSchemaElement.required,
-          description: jsonSchemaElement.description,
-          schema: {
-            type: jsonSchemaElement.type
-          }
+          required,
+          description,
+          schema
+          // currently not handled, since they are not JSON Schema properties:
+          // style
+          // explode
+          // allowReserved
+          // per media type
         }
 
         const media = schemaToMedia(jsonSchemaElement)

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -185,6 +185,9 @@ function plainJsonObjectToOpenapi3 (container, jsonSchema, externalSchemas, secu
         // optionally add serialization format style
         if (jsonSchema.style) result.style = jsonSchema.style
         if (jsonSchema.explode != null) result.explode = jsonSchema.explode
+        if (jsonSchema.allowReserved === true && container === 'query') {
+          result.allowReserved = jsonSchema.allowReserved
+        }
         return result
       }
       break

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -140,9 +140,7 @@ function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas, secu
         return {
           in: 'header',
           name: propertyName,
-          required: jsonSchemaElement.required,
-          description: jsonSchemaElement.description,
-          type: jsonSchemaElement.type
+          ...jsonSchemaElement
         }
       }
       break

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -99,12 +99,13 @@ function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas, secu
   const obj = resolveLocalRef(jsonSchema, externalSchemas)
   let toSwaggerProp
   switch (container) {
+    case 'header':
     case 'query':
       toSwaggerProp = function (propertyName, jsonSchemaElement) {
         // complex serialization is not supported by swagger
         if (jsonSchemaElement[xConsume]) {
           throw new Error('Complex serialization is not supported by Swagger. ' +
-            'Remove "' + xConsume + '" for "' + propertyName + '" querystring schema or ' +
+            'Remove "' + xConsume + '" for "' + propertyName + '" querystring/header schema or ' +
             'change specification to OpenAPI')
         }
         jsonSchemaElement.in = container
@@ -133,15 +134,6 @@ function plainJsonObjectToSwagger2 (container, jsonSchema, externalSchemas, secu
         jsonSchemaElement.name = propertyName
         jsonSchemaElement.required = true
         return jsonSchemaElement
-      }
-      break
-    case 'header':
-      toSwaggerProp = function (propertyName, jsonSchemaElement) {
-        return {
-          in: 'header',
-          name: propertyName,
-          ...jsonSchemaElement
-        }
       }
       break
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "homepage": "https://github.com/fastify/fastify-swagger#readme",
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
+    "@fastify/cookie": "^8.3.0",
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^18.0.0",
     "fastify": "^4.0.0",

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -282,3 +282,74 @@ test('uses examples if has property required in body', async (t) => {
   t.ok(schema.parameters)
   t.same(schema.parameters[0].in, 'query')
 })
+
+test('renders $ref schema with enum in headers', async (t) => {
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, { openapi: {} })
+  fastify.register(async (instance) => {
+    instance.addSchema({ $id: 'headerA', type: 'object', properties: { 'x-enum-header': { type: 'string', enum: ['OK', 'NOT_OK'] } } })
+    instance.get('/url1', { schema: { headers: { $ref: 'headerA#' }, response: { 200: { type: 'object' } } } }, async () => ({ result: 'OK' }))
+  })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+
+  await Swagger.validate(openapiObject)
+
+  // the OpenAPI spec should show the enum
+  t.match(openapiObject.paths['/url1'].get.parameters[0].schema, { type: 'string', enum: ['OK', 'NOT_OK'] })
+})
+
+test('renders $ref schema with additional keywords', async (t) => {
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, { openapi: {} })
+  await fastify.register(require('@fastify/cookie'))
+
+  const cookie = {
+    type: 'object',
+    properties: {
+      a: { type: 'string' },
+      b: { type: 'string' },
+      c: { type: 'string' }
+    },
+    minProperties: 2
+  }
+
+  fastify.register(async (instance) => {
+    instance.addSchema({
+      $id: 'headerA',
+      type: 'object',
+      properties: {
+        cookie
+      }
+    })
+
+    instance.get('/url1', {
+      preValidation: async (request) => {
+        request.headers.cookie = request.cookies
+      },
+      schema: {
+        headers: {
+          $ref: 'headerA#'
+        }
+      }
+    }, async (req) => (req.headers))
+  })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+
+  await Swagger.validate(openapiObject)
+
+  let res = await fastify.inject({ method: 'GET', url: 'url1', cookies: { a: 'hi', b: 'asd' } })
+
+  t.match(res.statusCode, 200)
+
+  res = await fastify.inject({ method: 'GET', url: 'url1', cookies: { a: 'hi' } })
+
+  t.match(res.statusCode, 400)
+
+  t.match(openapiObject.paths['/url1'].get.parameters[0].schema, cookie)
+})

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -338,10 +338,10 @@ test('renders $ref schema with additional keywords', async (t) => {
   })
 
   await fastify.ready()
-
   const openapiObject = fastify.swagger()
-
   await Swagger.validate(openapiObject)
+
+  t.match(openapiObject.paths['/url1'].get.parameters[0].schema, cookie)
 
   let res = await fastify.inject({ method: 'GET', url: 'url1', cookies: { a: 'hi', b: 'asd' } })
 
@@ -350,6 +350,5 @@ test('renders $ref schema with additional keywords', async (t) => {
   res = await fastify.inject({ method: 'GET', url: 'url1', cookies: { a: 'hi' } })
 
   t.match(res.statusCode, 400)
-
   t.match(openapiObject.paths['/url1'].get.parameters[0].schema, cookie)
 })

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -818,6 +818,7 @@ test('support query serialization params', async t => {
         style: 'deepObject',
         explode: false,
         type: 'object',
+        allowReserved: true,
         properties: {
           obj: {
             type: 'string'
@@ -833,6 +834,7 @@ test('support query serialization params', async t => {
         function (ajv) {
           ajv.addKeyword({ keyword: 'style' })
           ajv.addKeyword({ keyword: 'explode' })
+          ajv.addKeyword({ keyword: 'allowReserved' })
         }
       ]
     }
@@ -847,4 +849,5 @@ test('support query serialization params', async t => {
   const api = await Swagger.validate(swaggerObject)
   t.equal(api.paths['/'].get.parameters[0].style, 'deepObject')
   t.equal(api.paths['/'].get.parameters[0].explode, false)
+  t.equal(api.paths['/'].get.parameters[0].allowReserved, true)
 })

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -70,7 +70,6 @@ test('support - oneOf, anyOf, allOf in headers', async (t) => {
       required: false,
       in: 'header',
       name: 'foo',
-      description: undefined,
       schema: {
         type: 'string'
       }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Instead of just fixing the problem for `enum` (see #701), I assume we can pass everything from the JSON Schema into the OpenAPI parameter's spec.
See the last OpenAPI test for an, admittedly, contrived scenario, which may however show why it may be short-sighted to only render the `string` specific keywords (`pattern`, `format`, `minLength`, `maxLength`). [This test is only for demo purposes]

Whenever the type is not `string`, it may make sense to make to explicitly set the `style` property.
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#style-values

In the end, this is similar to how we handle `query` parameters already, so this PR ended up basically just removing code.

While I'd always recommend separating the OpenAPI (Web) specific spec props (`style`, `explode`) from the JSON Schema, we pass it on in case of query params, so we should do that for headers the same way we treat query params anyway.

~~Currently, we do not pass `allowReserved` (OpenAPI v3), which I assume to be missing rather than an intended exclusion, in that case, should we add it?~~ Added