### PR TITLE
Hide HEAD routes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,13 +301,12 @@ To deep down the `buildLocalReference` arguments, you may read the [documentatio
 ### Route options
 
 It is possible to instruct `@fastify/swagger` to include specific `HEAD` routes in the definitions
-by adding `exposeHeadRoute` to the route schema definition, like so:
+by adding `exposeHeadRoute` in the route config, like so:
 
 ```js
   fastify.get('/with-head', {
     schema: {
       operationId: 'with-head',
-      exposeHeadRoute: true,
       response: {
         200: {
           description: 'Expected Response',
@@ -316,6 +315,11 @@ by adding `exposeHeadRoute` to the route schema definition, like so:
             foo: { type: 'string' }
           }
         }
+      }
+    },
+    config: {
+      swagger: {
+        exposeHeadRoute: true,
       }
     }
   }, () => {})

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
  | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                               |
  | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                             |                                                                 |
  | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
- | exposeHeadRoutes   | false            | Include HEAD routes into the definitions                                                                                   |
+ | exposeHeadRoutes   | false            | Include HEAD routes in the definitions                                                                                   |
 
 <a name="register.options.transform"></a>
 #### Transform

--- a/README.md
+++ b/README.md
@@ -209,16 +209,17 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
 
 #### Options
 
- | Option             | Default          | Description                                                                                                               |
- | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
- | hiddenTag          | X-HIDDEN         | Tag to control hiding of routes.                                                                                          |
- | hideUntagged       | false            | If `true` remove routes without tags from resulting Swagger/OpenAPI schema file.                                          |
- | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).     |
- | openapi            | {}               | [OpenAPI configuration](https://swagger.io/specification/#oasObject).                                                     |
- | stripBasePath      | true             | Strips base path from routes in docs.                                                                                     |
- | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                              |
- | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                                                                                              |
+ | Option             | Default          | Description                                                                                                                |
+ | ------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+ | hiddenTag          | X-HIDDEN         | Tag to control hiding of routes.                                                                                           |
+ | hideUntagged       | false            | If `true` remove routes without tags from resulting Swagger/OpenAPI schema file.                                           |
+ | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).      |
+ | openapi            | {}               | [OpenAPI configuration](https://swagger.io/specification/#oasObject).                                                      |
+ | stripBasePath      | true             | Strips base path from routes in docs.                                                                                      |
+ | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                               |
+ | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                             |                                                                 |
  | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
+ | exposeHeadRoutes   | false            | Include HEAD routes into the definitions                                                                                   |
 
 <a name="register.options.transform"></a>
 #### Transform
@@ -298,6 +299,27 @@ To deep down the `buildLocalReference` arguments, you may read the [documentatio
 
 <a name="route.options"></a>
 ### Route options
+
+It is possible to instruct `@fastify/swagger` to include specific `HEAD` routes in the definitions
+by adding `exposeHeadRoute` to the route schema definition, like so:
+
+```js
+  fastify.get('/with-head', {
+    schema: {
+      operationId: 'with-head',
+      exposeHeadRoute: true,
+      response: {
+        200: {
+          description: 'Expected Response',
+          type: 'object',
+          properties: {
+            foo: { type: 'string' }
+          }
+        }
+      }
+    }
+  }, () => {})
+```
 
 <a name="route.response.options"></a>
 #### Response Options

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -12,8 +12,9 @@ function addHook (fastify, pluginOptions) {
   const sharedSchemasMap = new Map()
 
   fastify.addHook('onRoute', (routeOptions) => {
-    const schema = routeOptions.schema || {}
-    if (routeOptions.method === 'HEAD' && pluginOptions.exposeHeadRoutes !== true && schema.exposeHeadRoute !== true) {
+    const routeConfig = routeOptions.config || {}
+    const swaggerConfig = routeConfig.swagger || {}
+    if (routeOptions.method === 'HEAD' && pluginOptions.exposeHeadRoutes !== true && swaggerConfig.exposeHeadRoute !== true) {
       return
     }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -11,26 +11,21 @@ function addHook (fastify, pluginOptions) {
   const routes = []
   const sharedSchemasMap = new Map()
 
-  const globalExposeHeadRoutes = fastify.initialConfig.exposeHeadRoutes
-
   fastify.addHook('onRoute', (routeOptions) => {
-    // fastify will generate HEAD routes if either the global `exposeHeadRoutes`
-    // (default behavior since https://github.com/fastify/fastify/pull/2826) or
-    // `exposeHeadRoute` on route level flag is `true`. If two routes with
-    // operationId are added to the swagger object, it is no longer valid.
-    // therefore we suffix the operationId with `-head`.
-    const hasRouteExposeHeadRouteFlag = routeOptions.exposeHeadRoute != null
-    const exposesHeads = hasRouteExposeHeadRouteFlag
-      ? routeOptions.exposeHeadRoute
-      : globalExposeHeadRoutes
+    const schema = routeOptions.schema || {}
+    if (routeOptions.method === 'HEAD' && pluginOptions.exposeHeadRoutes !== true && schema.exposeHeadRoute !== true) {
+      return
+    }
 
     if (
       routeOptions.method === 'HEAD' &&
-      exposesHeads === true &&
       routeOptions.schema !== undefined &&
       routeOptions.schema.operationId !== undefined
     ) {
       routes.push(
+        // If two routes with operationId are added to the swagger
+        // object, it is no longer valid.
+        // therefore we suffix the operationId with `-head`.
         Object.assign({}, routeOptions, {
           schema: Object.assign({}, routeOptions.schema, {
             operationId: `${routeOptions.schema.operationId}-head`

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -557,7 +557,7 @@ test('support "exposeHeadRoutes" option', async (t) => {
   )
 })
 
-test('support "exposeHeadRoutes" option inside the schema', async (t) => {
+test('support "exposeHeadRoutes" option at route level', async (t) => {
   const fastify = Fastify()
   await fastify.register(fastifySwagger, {
     routePrefix: '/docs',
@@ -567,7 +567,6 @@ test('support "exposeHeadRoutes" option inside the schema', async (t) => {
   fastify.get('/with-head', {
     schema: {
       operationId: 'with-head',
-      exposeHeadRoute: true,
       response: {
         200: {
           description: 'Expected Response',
@@ -576,6 +575,11 @@ test('support "exposeHeadRoutes" option inside the schema', async (t) => {
             foo: { type: 'string' }
           }
         }
+      }
+    },
+    config: {
+      swagger: {
+        exposeHeadRoute: true
       }
     }
   }, () => {})


### PR DESCRIPTION
This PR partially reverts https://github.com/fastify/fastify-swagger/pull/649 due to some unintended breakage. I had a couple of applications whose tests failed badly due to the HEAD routes now included in the definitions. This PR hides by default but add an option to expose them, both at the plugin level or at the route level.
The plugin would rely anymore on the Fastify own settings.

Fixes #722 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
