### PR TITLE
feat: support description field on openapi and swagger bodies

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -257,6 +257,10 @@ function resolveBodyParams (body, schema, consumes, ref) {
   if (resolved && resolved.required && resolved.required.length) {
     body.required = true
   }
+
+  if (resolved && resolved.description) {
+    body.description = resolved.description
+  }
 }
 
 function resolveCommonParams (container, parameters, schema, ref, sharedSchemas, securityIgnores) {

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -185,6 +185,7 @@ function resolveBodyParams (parameters, schema, ref) {
   parameters.push({
     name: 'body',
     in: 'body',
+    description: resolved && resolved.description ? resolved.description : undefined,
     schema: resolved
   })
 }

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -811,6 +811,50 @@ test('support object properties with special names', async t => {
   })
 })
 
+test('support "description" keyword', async t => {
+  const opt = {
+    schema: {
+      body: {
+        type: 'object',
+        description: 'Body description',
+        properties: {
+          foo: {
+            type: 'number'
+          }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, {
+    openapi: true
+  })
+  fastify.post('/', opt, () => { })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].post
+  t.same(definedPath.requestBody, {
+    description: 'Body description',
+    content: {
+      'application/json': {
+        schema: {
+          description: 'Body description',
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'number'
+            }
+          }
+        }
+      }
+    }
+  })
+})
+
 test('support query serialization params', async t => {
   const opt = {
     schema: {

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -482,6 +482,42 @@ test('support "const" keyword', async t => {
   })
 })
 
+test('support "description" keyword', async t => {
+  const opt = {
+    schema: {
+      body: {
+        type: 'object',
+        description: 'Body description',
+        properties: {
+          foo: {
+            type: 'number'
+          }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger)
+  fastify.post('/', opt, () => { })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].post
+  t.same(definedPath.parameters[0].description, 'Body description')
+  t.same(definedPath.parameters[0].schema, {
+    type: 'object',
+    description: 'Body description',
+    properties: {
+      foo: {
+        type: 'number'
+      }
+    }
+  })
+})
+
 test('no head routes by default', async (t) => {
   const fastify = Fastify({ exposeHeadRoutes: true })
   await fastify.register(fastifySwagger, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #717

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
