### PR TITLE
Don't use JSONObject for `transform`.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,7 +124,7 @@ declare namespace fastifySwagger {
     /**
      * custom function to transform the route's schema and url
      */
-    transform?: <S extends FastifySchema = FastifySchema>({ schema, url }: { schema: S, url: string }) => { schema: JSONObject, url: string };
+    transform?: <S extends FastifySchema = FastifySchema>({ schema, url }: { schema: S, url: string }) => { schema: FastifySchema, url: string };
 
     refResolver?: {
       /** Clone the input schema without changing it. Default to `false`. */

--- a/test/types/http2-types.test.ts
+++ b/test/types/http2-types.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifySwagger, {JSONObject} from '../..';
+import fastifySwagger from '../..';
 import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 
 const app = fastify({
@@ -9,7 +9,7 @@ const app = fastify({
 app.register(fastifySwagger);
 app.register(fastifySwagger, {});
 app.register(fastifySwagger, { transform: ({schema, url}) => ({
-        schema: schema as unknown as JSONObject,
+        schema: schema,
         url: url,
 })});
 app.register(fastifySwagger, {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -3,7 +3,7 @@ import fastifySwagger, {
   SwaggerOptions,
   FastifySwaggerInitOAuthOptions,
   FastifySwaggerUiConfigOptions,
-  FastifySwaggerUiHooksOptions, JSONObject,
+  FastifySwaggerUiHooksOptions,
 } from "../.."
 import { minimalOpenApiV3Document } from './minimal-openapiV3-document';
 import { expectType } from "tsd";
@@ -30,7 +30,7 @@ const uiHooks: FastifySwaggerUiHooksOptions = {
 app.register(fastifySwagger);
 app.register(fastifySwagger, {});
 app.register(fastifySwagger, { transform: ({schema, url}) => ({
-    schema: schema as unknown as JSONObject,
+    schema: schema,
     url: url,
 })});
 app.register(fastifySwagger, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I'll use CI to make sure `npm run test` and `npm run benchmark` are AOK. I can elaborate on *why* this change is necessary, but instead just look at the changes to the tests. BTW the example in the readme still works (once you change it by making `transformedSchema` be `...ts` then `const transformedSchema = ts as FastifySchema`).