### PR TITLE
feat: add api version filter based route version contraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,17 +209,18 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
 
 #### Options
 
- | Option             | Default          | Description                                                                                                                |
- | ------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
- | hiddenTag          | X-HIDDEN         | Tag to control hiding of routes.                                                                                           |
- | hideUntagged       | false            | If `true` remove routes without tags from resulting Swagger/OpenAPI schema file.                                           |
- | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).      |
- | openapi            | {}               | [OpenAPI configuration](https://swagger.io/specification/#oasObject).                                                      |
- | stripBasePath      | true             | Strips base path from routes in docs.                                                                                      |
- | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                               |
- | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                             |                                                                 |
- | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver) |
- | exposeHeadRoutes   | false            | Include HEAD routes in the definitions                                                                                   |
+ | Option             | Default          | Description                                                                                                                                                                   |
+ | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | hiddenTag          | X-HIDDEN         | Tag to control hiding of routes.                                                                                                                                              |
+ | hideUntagged       | false            | If `true` remove routes without tags from resulting Swagger/OpenAPI schema file.                                                                                              |
+ | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).                                                         |
+ | openapi            | {}               | [OpenAPI configuration](https://swagger.io/specification/#oasObject).                                                                                                         |
+ | stripBasePath      | true             | Strips base path from routes in docs.                                                                                                                                         |
+ | swagger            | {}               | [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject).                                                                                                  |
+ | transform          | null             | Transform method for the route's schema and url. [documentation](#register.options.transform).                                                                                |
+ | refResolver        | {}               | Option to manage the `$ref`s of your application's schemas. Read the [`$ref` documentation](#register.options.refResolver)                                                    |
+ | exposeHeadRoutes   | false            | Include HEAD routes in the definitions                                                                                                                                        |
+ | apiVersion         | undefined        | If provided, removes routes with a [version constraint](https://fastify.dev/docs/latest/Reference/Routes/#version-constraints) that do not match the provided a version range |
 
 <a name="register.options.transform"></a>
 #### Transform

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,15 @@ declare namespace fastifySwagger {
     openapi?: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>
     hiddenTag?: string;
     hideUntagged?: boolean;
+
+    /**
+     * Remove routes that do not satisfy the provided api version range
+     * 
+     * @example
+     * { apiVersion: '^2.0.0' }
+     */
+    apiVersion?: string;
+  
     /**
      * Strips matching base path from routes in documentation
      * @default true

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -35,7 +35,9 @@ module.exports = function (opts, cache, routes, Ref, done) {
       const schema = transformResult.schema || route.schema
       const shouldRouteHideOpts = {
         hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+        hideUntagged: defOpts.hideUntagged,
+        apiVersion: defOpts.apiVersion,
+        routeVersion: route?.constraints?.version
       }
 
       if (shouldRouteHide(schema, shouldRouteHideOpts)) continue

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -16,6 +16,7 @@ function prepareDefaultOptions (opts) {
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
   const hideUntagged = opts.hideUntagged
+  const apiVersion = opts.apiVersion
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.openapi)) {
@@ -36,7 +37,8 @@ function prepareDefaultOptions (opts) {
     transform,
     hiddenTag,
     extensions,
-    hideUntagged
+    hideUntagged,
+    apiVersion
   }
 }
 

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -33,7 +33,9 @@ module.exports = function (opts, cache, routes, Ref, done) {
       const schema = transformResult.schema || route.schema
       const shouldRouteHideOpts = {
         hiddenTag: defOpts.hiddenTag,
-        hideUntagged: defOpts.hideUntagged
+        hideUntagged: defOpts.hideUntagged,
+        apiVersion: defOpts.apiVersion,
+        routeVersion: route?.constraints?.version
       }
 
       if (shouldRouteHide(schema, shouldRouteHideOpts)) continue

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -20,6 +20,7 @@ function prepareDefaultOptions (opts) {
   const transform = opts.transform
   const hiddenTag = opts.hiddenTag
   const hideUntagged = opts.hideUntagged
+  const apiVersion = opts.apiVersion
   const extensions = []
 
   for (const [key, value] of Object.entries(opts.swagger)) {
@@ -44,7 +45,8 @@ function prepareDefaultOptions (opts) {
     transform,
     hiddenTag,
     extensions,
-    hideUntagged
+    hideUntagged,
+    apiVersion
   }
 }
 

--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const Ref = require('json-schema-resolver')
 const cloner = require('rfdc')({ proto: true, circles: false })
+const semverSatisfies = require('semver/functions/satisfies')
 const { rawRequired } = require('../symbols')
 const { xConsume } = require('../constants')
 
@@ -77,7 +78,7 @@ function addHook (fastify, pluginOptions) {
 }
 
 function shouldRouteHide (schema, opts) {
-  const { hiddenTag, hideUntagged } = opts
+  const { hiddenTag, hideUntagged, apiVersion, routeVersion } = opts
 
   if (schema && schema.hide) {
     return true
@@ -91,6 +92,10 @@ function shouldRouteHide (schema, opts) {
 
   if (tags.includes(hiddenTag)) {
     return schema.tags.includes(hiddenTag)
+  }
+
+  if (apiVersion && routeVersion && !semverSatisfies(routeVersion, apiVersion)) {
+    return true
   }
 
   return false

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "json-schema-resolver": "^2.0.0",
     "openapi-types": "^12.0.0",
     "rfdc": "^1.3.0",
+    "semver": "^7.5.3",
     "yaml": "^2.2.2"
   },
   "standard": {


### PR DESCRIPTION
Adds the ability to provide an `apiVersion` config value with a semver
range.

The route version is sourced from the [fastify version constraint](https://fastify.dev/docs/latest/Reference/Routes/#version-constraints).

Semver parsing is completed using the `semver` package `satisfies` function, which has been added as a
new dependency.

closes #732

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
