### PR TITLE
feat: add route, openapi and swagger objects to transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,14 @@ An example of using `@fastify/swagger` with `static` mode enabled can be found [
 
 By passing a synchronous `transform` function you can modify the route's url and schema.
 
+You may also access the `openapiObject` and `swaggerObject`
+
 Some possible uses of this are:
 
 - add the `hide` flag on schema according to your own logic based on url & schema
 - altering the route url into something that's more suitable for the api spec
 - using different schemas such as [Joi](https://github.com/hapijs/joi) and transforming them to standard JSON schemas expected by this plugin
+- hiding routes based on version constraints
 
 This option is available in `dynamic` mode only.
 
@@ -241,7 +244,7 @@ const convert = require('joi-to-json')
 
 await fastify.register(require('@fastify/swagger'), {
   swagger: { ... },
-  transform: ({ schema, url }) => {
+  transform: ({ schema, url, route, swaggerObject }) => {
     const {
       params,
       body,
@@ -265,6 +268,9 @@ await fastify.register(require('@fastify/swagger'), {
 
     // can transform the url
     if (url.startsWith('/latest_version/endpoint')) transformedUrl = url.replace('latest_version', 'v3')
+
+    // can add the hide tag for routes that do not match the swaggerObject version
+    if (route?.constraints?.version !== swaggerObject.swagger) transformedSchema.hide = true
 
     return { schema: transformedSchema, url: transformedUrl }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback, FastifySchema, onRequestHookHandler, preHandlerHookHandler } from 'fastify';
+import { FastifyPluginCallback, FastifySchema, FastifyRequest, onRequestHookHandler, preHandlerHookHandler } from 'fastify';
 import { OpenAPI, OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
 /**
@@ -124,7 +124,13 @@ declare namespace fastifySwagger {
     /**
      * custom function to transform the route's schema and url
      */
-    transform?: <S extends FastifySchema = FastifySchema>({ schema, url }: { schema: S, url: string }) => { schema: FastifySchema, url: string };
+    transform?: <S extends FastifySchema = FastifySchema>({ schema, url, route, swaggerObject, openapiObject }: {
+      schema: S,
+      url: string,
+      route: FastifyRequest,
+      swaggerObject: Partial<OpenAPIV2.Document>
+      openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>
+    }) => { schema: FastifySchema, url: string };
 
     refResolver?: {
       /** Clone the input schema without changing it. Default to `false`. */

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -29,7 +29,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
     for (const route of routes) {
       const transformResult = defOpts.transform
-        ? defOpts.transform({ schema: route.schema, url: route.url })
+        ? defOpts.transform({ schema: route.schema, url: route.url, route, openapiObject })
         : {}
 
       const schema = transformResult.schema || route.schema

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -27,7 +27,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
     swaggerObject.paths = {}
     for (const route of routes) {
       const transformResult = defOpts.transform
-        ? defOpts.transform({ schema: route.schema, url: route.url })
+        ? defOpts.transform({ schema: route.schema, url: route.url, route, swaggerObject })
         : {}
 
       const schema = transformResult.schema || route.schema

--- a/test/transform.js
+++ b/test/transform.js
@@ -56,3 +56,67 @@ test('transform should work with a Function', async (t) => {
   await fastify.ready()
   t.doesNotThrow(fastify.swagger)
 })
+
+test('transform can access route', async (t) => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    openapi: { info: { version: '1.0.0' } },
+    transform: ({ route }) => {
+      t.ok(route)
+      t.equal(route.method, 'GET')
+      t.equal(route.url, '/example')
+      t.equal(route.constraints.version, '1.0.0')
+      return { schema: route.schema, url: route.url }
+    }
+  })
+  fastify.get('/example', { constraints: { version: '1.0.0' } }, () => {})
+
+  await fastify.ready()
+  t.doesNotThrow(fastify.swagger)
+})
+
+test('transform can access openapi object', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    openapi: { info: { version: '1.0.0' } },
+    transform: ({ route, openapiObject }) => {
+      t.ok(openapiObject)
+      t.equal(openapiObject.openapi, '3.0.3')
+      t.equal(openapiObject.info.version, '1.0.0')
+      return {
+        schema: route.schema,
+        url: route.url
+      }
+    }
+  })
+  fastify.get('/example', () => {})
+
+  await fastify.ready()
+  t.doesNotThrow(fastify.swagger)
+})
+
+test('transform can access swagger object', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    swagger: { info: { version: '1.0.0' } },
+    transform: ({ route, swaggerObject }) => {
+      t.ok(swaggerObject)
+      t.equal(swaggerObject.swagger, '2.0')
+      t.equal(swaggerObject.info.version, '1.0.0')
+      return {
+        schema: route.schema,
+        url: route.url
+      }
+    }
+  })
+  fastify.get('/example', () => {})
+
+  await fastify.ready()
+  t.doesNotThrow(fastify.swagger)
+})


### PR DESCRIPTION
Add `route`, `openapiObject`, and `swaggerObject` to the transform hook parameters.

Keeps `schema` and `url` as param to avoid breaking changes

```js
// openapi
await fastify.register(fastifySwagger, {
  openapi: {},
  transform: ({ schema, url, route, openapiObject }) => {
    // do something with openapiObject
    // do something with route e.g route.constraints.version
    return {
      schema: route.schema,
      url: route.url
    }
  }
})
await fastify.register(fastifySwagger, {
  swagger: {},
  transform: ({ schema, url, route swaggerObject }) => {
    // do something with swaggerObject
    return { schema, url }
  }
})
```




closes #737 access to version via `openapiObject.openapi` or `swaggerObject.swagger`
closes #732 access to route version via `route.constraints.version`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
