### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
+const path = require('node:path')
+const fs = require('node:fs')
 const yaml = require('yaml')
 
 module.exports = function (fastify, opts, done) {

--- a/lib/util/read-package-json.js
+++ b/lib/util/read-package-json.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 function readPackageJson () {
   try {

--- a/test/mode/static.js
+++ b/test/mode/static.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const { test } = require('tap')
 const Fastify = require('fastify')
 const fastifySwagger = require('../../index')
 const fastifySwaggerDynamic = require('../../lib/mode/dynamic')
 const Swagger = require('@apidevtools/swagger-parser')
-const readFileSync = require('fs').readFileSync
-const resolve = require('path').resolve
+const readFileSync = require('node:fs').readFileSync
+const resolve = require('node:path').resolve
 const yaml = require('yaml')
 
 test('specification validation check works', async (t) => {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
