### PR TITLE
Fix race condition that have the spec cached if .swagger() is called before ready()

### DIFF
--- a/lib/util/add-hook.js
+++ b/lib/util/add-hook.js
@@ -6,6 +6,7 @@ const cloner = require('rfdc')({ proto: true, circles: false })
 function addHook (fastify, pluginOptions) {
   const routes = []
   const sharedSchemasMap = new Map()
+  let hookRun = false
 
   fastify.addHook('onRoute', (routeOptions) => {
     const routeConfig = routeOptions.config || {}
@@ -51,6 +52,7 @@ function addHook (fastify, pluginOptions) {
   })
 
   fastify.addHook('onReady', (done) => {
+    hookRun = true
     const allSchemas = fastify.getSchemas()
     for (const schemaId of Object.keys(allSchemas)) {
       // it is the top-level, we do not expect to have duplicate id
@@ -62,6 +64,9 @@ function addHook (fastify, pluginOptions) {
   return {
     routes,
     Ref () {
+      if (hookRun === false) {
+        throw new Error('.swagger() must be called after .ready()')
+      }
       const externalSchemas = cloner(Array.from(sharedSchemasMap.values()))
       return Ref(Object.assign(
         { applicationUri: 'todo.com' },

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -13,3 +13,23 @@ test('fastify.swagger should exist', async (t) => {
   await fastify.ready()
   t.ok(fastify.swagger)
 })
+
+test('fastify.swagger should throw if called before ready', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger)
+
+  t.throws(fastify.swagger.bind(fastify))
+})
+
+test('fastify.swagger should throw if called before ready (openapi)', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    openapi: {}
+  })
+
+  t.throws(fastify.swagger.bind(fastify))
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
