### PR TITLE
feat: support for webhooks option according to Open Api 3.1.0

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -63,6 +63,80 @@ const openapiOption = {
   }
 }
 
+const openapiWebHookOption = {
+  openapi: {
+    openapi: '3.1.0',
+    info: {
+      title: 'Test swagger',
+      description: 'testing the fastify swagger api',
+      version: '0.1.0'
+    },
+    servers: [
+      {
+        url: 'http://localhost'
+      }
+    ],
+    tags: [{ name: 'tag' }],
+    components: {
+      securitySchemes: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'header'
+        }
+      },
+      schemas: {
+        Pet: {
+          require: ['id', 'name'],
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64'
+            },
+            name: {
+              type: 'string'
+            },
+            tag: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    },
+    security: [
+      {
+        apiKey: []
+      }
+    ],
+    externalDocs: {
+      description: 'Find more info here',
+      url: 'https://swagger.io'
+    },
+    webhooks: {
+      newPet: {
+        post: {
+          requestBody: {
+            description: 'Information about a new pet in the system',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Pet'
+                }
+              }
+            }
+          },
+          responses: {
+            200: {
+              description:
+                'Return a 200 status to indicate that the data was received successfully'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 const openapiRelativeOptions = {
   openapi: {
     info: {
@@ -287,6 +361,7 @@ const schemaOperationId = {
 module.exports = {
   openapiOption,
   openapiRelativeOptions,
+  openapiWebHookOption,
   swaggerOption,
   schemaQuerystring,
   schemaBody,

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -60,6 +60,7 @@ function prepareOpenapiObject (opts) {
   if (opts.info) openapiObject.info = opts.info
   if (opts.servers) openapiObject.servers = opts.servers
   if (opts.components) openapiObject.components = Object.assign({}, opts.components, { schemas: Object.assign({}, opts.components.schemas) })
+  if (opts.webhooks) openapiObject.webhooks = opts.webhooks
   if (opts.security) openapiObject.security = opts.security
   if (opts.tags) openapiObject.tags = opts.tags
   if (opts.externalDocs) openapiObject.externalDocs = opts.externalDocs


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #728 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
   -  Since there is already an explanation of OpenApi options, I thought it unnecessary to add it to the README.
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
