### PR TITLE
feat: generate path params definition when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Please specify `type: 'null'` for the response otherwise Fastify itself will fai
 <a name="route.openapi"></a>
 #### OpenAPI Parameter Options
 
-**Note:** OpenAPI's terminology differs from Fastify's. OpenAPI uses "parameter" to refer to parts of a request that in [Fastify's validation documentation](https://www.fastify.io/docs/latest/Validation-and-Serialization/#validation) are called "querystring", "params", and "headers".
+**Note:** OpenAPI's terminology differs from Fastify's. OpenAPI uses "parameter" to refer to parts of a request that in [Fastify's validation documentation](https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/) are called "querystring", "params", and "headers".
 
 OpenAPI provides some options beyond those provided by the [JSON schema specification](https://json-schema.org/specification.html) for specifying the shape of parameters. A prime example of this is the `collectionFormat` option for specifying how to encode parameters that should be handled as arrays of values.
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,145 @@ Will generate this in the OpenAPI v3 schema's `paths`:
 }
 ```
 
+##### Route parameters
+
+Route parameters in Fastify are called params, these are values included in the URL of the requests, for example:
+
+```js
+fastify.route({
+  method: 'GET',
+  url: '/:id',
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'user id'
+        }
+      }
+    }
+  },
+  handler (request, reply) {
+    reply.send(request.params.id)
+  }
+})
+```
+
+Will generate this in the Swagger (OpenAPI v2) schema's `paths`:
+
+```json
+{
+  "/{id}": {
+    "get": {
+      "parameters": [
+        {
+          "type": "string",
+          "description": "user id",
+          "required": true,
+          "in": "path",
+          "name": "id"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Default Response"
+        }
+      }
+    }
+  }
+}
+```
+
+Will generate this in the OpenAPI v3 schema's `paths`:
+
+```json
+{
+  "/{id}": {
+    "get": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "description": "user id"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Default Response"
+        }
+      }
+    }
+  }
+}
+```
+
+Whether `params` is not present in the schema, or a schema is not provided, parameters are automatically generated, for example:
+
+```js
+fastify.route({
+  method: 'POST',
+  url: '/:id',
+  handler (request, reply) {
+    reply.send(request.params.id)
+  }
+})
+```
+
+Will generate this in the Swagger (OpenAPI v2) schema's `paths`:
+
+```json
+{
+  "/{id}": {
+    "get": {
+      "parameters": [
+        {
+          "type": "string",
+          "required": true,
+          "in": "path",
+          "name": "id"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Default Response"
+        }
+      }
+    }
+  }
+}
+```
+
+Will generate this in the OpenAPI v3 schema's `paths`:
+
+```json
+{
+  "/{id}": {
+    "get": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "name": "id",
+          "required": true
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Default Response"
+        }
+      }
+    }
+  }
+}
+```
+
 <a name="route.links"></a>
 #### Links
 

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -49,7 +49,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const openapiRoute = Object.assign({}, openapiObject.paths[url])
 
-      const openapiMethod = prepareOpenapiMethod(schema, ref, openapiObject)
+      const openapiMethod = prepareOpenapiMethod(schema, ref, openapiObject, url)
 
       if (route.links) {
         for (const statusCode of Object.keys(route.links)) {

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -411,8 +411,8 @@ function prepareOpenapiMethod (schema, ref, openapiObject, url) {
 
   // If there is no schema or schema.params, we need to generate them
   if ((!schema || !schema.params) && hasParams(url)) {
-    const schema = generateParamsSchema(url)
-    resolveCommonParams('path', parameters, schema.params, ref, openapiObject.definitions)
+    const schemaGenerated = generateParamsSchema(url)
+    resolveCommonParams('path', parameters, schemaGenerated.params, ref, openapiObject.definitions)
     openapiMethod.parameters = parameters
   }
 

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -5,6 +5,8 @@ const { formatParamUrl } = require('../../util/format-param-url')
 const { resolveLocalRef } = require('../../util/resolve-local-ref')
 const { xResponseDescription, xConsume, xExamples } = require('../../constants')
 const { rawRequired } = require('../../symbols')
+const { generateParamsSchema } = require('../../util/generate-params-schema')
+const { hasParams } = require('../../util/match-params')
 
 function prepareDefaultOptions (opts) {
   const openapi = opts.openapi
@@ -359,7 +361,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
   return responsesContainer
 }
 
-function prepareOpenapiMethod (schema, ref, openapiObject) {
+function prepareOpenapiMethod (schema, ref, openapiObject, url) {
   const openapiMethod = {}
   const parameters = []
 
@@ -405,6 +407,13 @@ function prepareOpenapiMethod (schema, ref, openapiObject) {
         openapiMethod[key] = schema[key]
       }
     }
+  }
+
+  // If there is no schema or schema.params, we need to generate them
+  if ((!schema || !schema.params) && hasParams(url)) {
+    const schema = generateParamsSchema(url)
+    resolveCommonParams('path', parameters, schema.params, ref, openapiObject.definitions)
+    openapiMethod.parameters = parameters
   }
 
   openapiMethod.responses = resolveResponse(schema ? schema.response : null, schema ? schema.produces : null, ref)

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -47,7 +47,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
 
       const swaggerRoute = Object.assign({}, swaggerObject.paths[url])
 
-      const swaggerMethod = prepareSwaggerMethod(schema, ref, swaggerObject)
+      const swaggerMethod = prepareSwaggerMethod(schema, ref, swaggerObject, url)
 
       if (route.links) {
         throw new Error('Swagger (Open API v2) does not support Links. Upgrade to OpenAPI v3 (see @fastify/swagger readme)')

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -4,6 +4,8 @@ const { readPackageJson } = require('../../util/read-package-json')
 const { formatParamUrl } = require('../../util/format-param-url')
 const { resolveLocalRef } = require('../../util/resolve-local-ref')
 const { xResponseDescription, xConsume } = require('../../constants')
+const { generateParamsSchema } = require('../../util/generate-params-schema')
+const { hasParams } = require('../../util/match-params')
 
 function prepareDefaultOptions (opts) {
   const swagger = opts.swagger
@@ -254,7 +256,7 @@ function resolveResponse (fastifyResponseJson, ref) {
   return responsesContainer
 }
 
-function prepareSwaggerMethod (schema, ref, swaggerObject) {
+function prepareSwaggerMethod (schema, ref, swaggerObject, url) {
   const swaggerMethod = {}
   const parameters = []
 
@@ -300,6 +302,13 @@ function prepareSwaggerMethod (schema, ref, swaggerObject) {
         swaggerMethod[key] = schema[key]
       }
     }
+  }
+
+  // If there is no schema or schema.params, we need to generate them
+  if ((!schema || !schema.params) && hasParams(url)) {
+    const schema = generateParamsSchema(url)
+    resolveCommonParams('path', parameters, schema.params, ref, swaggerObject.definitions)
+    swaggerMethod.parameters = parameters
   }
 
   swaggerMethod.responses = resolveResponse(schema ? schema.response : null, ref)

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -306,8 +306,8 @@ function prepareSwaggerMethod (schema, ref, swaggerObject, url) {
 
   // If there is no schema or schema.params, we need to generate them
   if ((!schema || !schema.params) && hasParams(url)) {
-    const schema = generateParamsSchema(url)
-    resolveCommonParams('path', parameters, schema.params, ref, swaggerObject.definitions)
+    const schemaGenerated = generateParamsSchema(url)
+    resolveCommonParams('path', parameters, schemaGenerated.params, ref, swaggerObject.definitions)
     swaggerMethod.parameters = parameters
   }
 

--- a/lib/util/generate-params-schema.js
+++ b/lib/util/generate-params-schema.js
@@ -31,6 +31,5 @@ function generateParamsSchema (url) {
 
 module.exports = {
   generateParamsSchema,
-  paramType,
   paramName
 }

--- a/lib/util/generate-params-schema.js
+++ b/lib/util/generate-params-schema.js
@@ -4,10 +4,6 @@ const { matchParams } = require('./match-params')
 
 const namePattern = /\{([^}]+)\}/
 
-function paramType () {
-  return 'string'
-}
-
 function paramName (param) {
   return param.replace(namePattern, (_, captured) => captured)
 }

--- a/lib/util/generate-params-schema.js
+++ b/lib/util/generate-params-schema.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { matchParams } = require('./match-params')
+
+const namePattern = /\{([^}]+)\}/
+
+function paramType () {
+  return 'string'
+}
+
+function paramName (param) {
+  return param.replace(namePattern, (_, captured) => captured)
+}
+
+// Generates default parameters schema from the given URL. (ex: /example/{userId})
+function generateParamsSchema (url) {
+  const params = matchParams(url)
+  const schema = {
+    params: {
+      type: 'object',
+      properties: {}
+    }
+  }
+
+  schema.params.properties = params.reduce((acc, param) => {
+    const name = paramName(param)
+    acc[name] = {
+      type: paramType()
+    }
+    return acc
+  }, {})
+
+  return schema
+}
+
+module.exports = {
+  generateParamsSchema,
+  paramType,
+  paramName
+}

--- a/lib/util/generate-params-schema.js
+++ b/lib/util/generate-params-schema.js
@@ -25,7 +25,7 @@ function generateParamsSchema (url) {
   schema.params.properties = params.reduce((acc, param) => {
     const name = paramName(param)
     acc[name] = {
-      type: paramType()
+      type: 'string'
     }
     return acc
   }, {})

--- a/lib/util/match-params.js
+++ b/lib/util/match-params.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const paramPattern = /\{[^{}]+\}/g
+
+function hasParams (url) {
+  if (!url) return false
+  const matches = url.match(paramPattern)
+  return matches !== null && matches.length > 0
+}
+
+function matchParams (url) {
+  if (!url) return []
+  return url.match(paramPattern) || []
+}
+
+module.exports = {
+  hasParams,
+  matchParams
+}

--- a/lib/util/match-params.js
+++ b/lib/util/match-params.js
@@ -4,8 +4,7 @@ const paramPattern = /\{[^{}]+\}/g
 
 function hasParams (url) {
   if (!url) return false
-  const matches = url.match(paramPattern)
-  return matches !== null && matches.length > 0
+  return paramPattern.test(url)
 }
 
 function matchParams (url) {

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -862,3 +862,33 @@ test('path params on relative url', async (t) => {
     }
   ])
 })
+
+test('verify generated path param definition with route prefixing', async (t) => {
+  const opts = {
+    schema: {}
+  }
+
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiRelativeOptions)
+  await fastify.register(function (app, _, done) {
+    app.get('/:userId', opts, () => {})
+
+    done()
+  }, { prefix: '/v1' })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/v1/{userId}'].get
+
+  t.same(definedPath.parameters, [{
+    schema: {
+      type: 'string'
+    },
+    in: 'path',
+    name: 'userId',
+    required: true
+  }])
+})

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -927,7 +927,7 @@ test('add default properties for url params when missing schema', async t => {
 
   const definedPath = api.paths['/{userId}'].get
 
-  t.same(definedPath.parameters[0], {
+  t.strictSame(definedPath.parameters[0], {
     in: 'path',
     name: 'userId',
     required: true,
@@ -963,7 +963,7 @@ test('add default properties for url params when missing schema.params', async t
 
   const definedPath = api.paths['/{userId}'].post
 
-  t.same(definedPath.parameters[0], {
+  t.strictSame(definedPath.parameters[0], {
     in: 'path',
     name: 'userId',
     required: true,
@@ -971,7 +971,7 @@ test('add default properties for url params when missing schema.params', async t
       type: 'string'
     }
   })
-  t.same(definedPath.requestBody.content['application/json'].schema.properties, {
+  t.strictSame(definedPath.requestBody.content['application/json'].schema.properties, {
     bio: {
       type: 'string'
     }
@@ -1011,7 +1011,7 @@ test('avoid overwriting params when schema.params is provided', async t => {
 
   const definedPath = swaggerObject.paths['/{userId}'].post
 
-  t.same(definedPath.parameters[0], {
+  t.strictSame(definedPath.parameters[0], {
     in: 'path',
     name: 'id',
     required: true,
@@ -1019,7 +1019,7 @@ test('avoid overwriting params when schema.params is provided', async t => {
       type: 'string'
     }
   })
-  t.same(definedPath.requestBody.content['application/json'].schema.properties, {
+  t.strictSame(definedPath.requestBody.content['application/json'].schema.properties, {
     bio: {
       type: 'string'
     }

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -555,3 +555,31 @@ test('security querystrings ignored when declared in security and securityScheme
   t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
   t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
+
+test('verify generated path param definition with route prefixing', async (t) => {
+  const opts = {
+    schema: {}
+  }
+
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(function (app, _, done) {
+    app.get('/:userId', opts, () => {})
+
+    done()
+  }, { prefix: '/v1' })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/v1/{userId}'].get
+
+  t.same(definedPath.parameters, [{
+    in: 'path',
+    name: 'userId',
+    type: 'string',
+    required: true
+  }])
+})

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -664,7 +664,7 @@ test('add default properties for url params when missing schema', async t => {
 
   const definedPath = api.paths['/{userId}'].get
 
-  t.same(definedPath.parameters[0], {
+  t.strictSame(definedPath.parameters[0], {
     type: 'string',
     required: true,
     in: 'path',
@@ -696,7 +696,7 @@ test('add default properties for url params when missing schema.params', async t
 
   const definedPath = api.paths['/{userId}'].post
 
-  t.same(definedPath.parameters[0].schema, {
+  t.strictSame(definedPath.parameters[0].schema, {
     type: 'object',
     properties: {
       bio: {
@@ -704,7 +704,7 @@ test('add default properties for url params when missing schema.params', async t
       }
     }
   })
-  t.same(definedPath.parameters[1], {
+  t.strictSame(definedPath.parameters[1], {
     in: 'path',
     name: 'userId',
     type: 'string',
@@ -743,7 +743,7 @@ test('avoid overwriting params when schema.params is provided', async t => {
 
   const definedPath = swaggerObject.paths['/{userId}'].post
 
-  t.same(definedPath.parameters[0].schema, {
+  t.strictSame(definedPath.parameters[0].schema, {
     type: 'object',
     properties: {
       bio: {
@@ -751,7 +751,7 @@ test('avoid overwriting params when schema.params is provided', async t => {
       }
     }
   })
-  t.same(definedPath.parameters[1], {
+  t.strictSame(definedPath.parameters[1], {
     in: 'path',
     name: 'id',
     type: 'string',

--- a/test/util.js
+++ b/test/util.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const { formatParamUrl } = require('../lib/util/format-param-url')
 const { hasParams, matchParams } = require('../lib/util/match-params')
-const { generateParamsSchema, paramType, paramName } = require('../lib/util/generate-params-schema')
+const { generateParamsSchema, paramName } = require('../lib/util/generate-params-schema')
 
 const cases = [
   ['/example/:userId', '/example/{userId}'],
@@ -137,17 +137,6 @@ test('generateParamsSchema function', (t) => {
 
     t.same(result, expectedSchema)
   }
-})
-
-test('paramType function', (t) => {
-  t.test('should return "string" for non-empty param', (t) => {
-    const param = '{userId}'
-    const result = paramType(param)
-    t.equal(result, 'string')
-    t.end()
-  })
-
-  t.end()
 })
 
 test('paramName function', (t) => {


### PR DESCRIPTION
Generate default param schema only if user doesn't specify a schema for param at all. If there is something, even with missing params, we should not modify it.

**Suggested solution**

- Check for params in the normalized url and for missing params in schema
- Generate a schema from the params found in the url
- Resolve params to the destination format using the previously generated schema
- Apply this behaviour to both specs

Closes https://github.com/fastify/fastify-swagger/issues/750