### PR TITLE
fix: openapi/swagger options path

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -62,6 +62,7 @@ function prepareOpenapiObject (opts) {
   if (opts.info) openapiObject.info = opts.info
   if (opts.servers) openapiObject.servers = opts.servers
   if (opts.components) openapiObject.components = Object.assign({}, opts.components, { schemas: Object.assign({}, opts.components.schemas) })
+  if (opts.paths) openapiObject.paths = opts.paths
   if (opts.webhooks) openapiObject.webhooks = opts.webhooks
   if (opts.security) openapiObject.security = opts.security
   if (opts.tags) openapiObject.tags = opts.tags

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -24,7 +24,6 @@ module.exports = function (opts, cache, routes, Ref, done) {
       ...(ref.definitions().definitions)
     }, ref)
 
-    swaggerObject.paths = {}
     for (const route of routes) {
       const transformResult = route.config?.swaggerTransform !== undefined
         ? route.config.swaggerTransform

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -15,6 +15,7 @@ function prepareDefaultOptions (opts) {
   const consumes = swagger.consumes || null
   const produces = swagger.produces || null
   const definitions = swagger.definitions || null
+  const paths = swagger.paths || null
   const basePath = swagger.basePath || null
   const securityDefinitions = swagger.securityDefinitions || null
   const security = swagger.security || null
@@ -40,6 +41,7 @@ function prepareDefaultOptions (opts) {
     consumes,
     produces,
     definitions,
+    paths,
     basePath,
     securityDefinitions,
     security,
@@ -73,6 +75,7 @@ function prepareSwaggerObject (opts) {
   if (opts.consumes) swaggerObject.consumes = opts.consumes
   if (opts.produces) swaggerObject.produces = opts.produces
   if (opts.definitions) swaggerObject.definitions = opts.definitions
+  if (opts.paths) swaggerObject.paths = opts.paths
   if (opts.securityDefinitions) swaggerObject.securityDefinitions = opts.securityDefinitions
   if (opts.security) swaggerObject.security = opts.security
   if (opts.tags) swaggerObject.tags = opts.tags

--- a/test/spec/openapi/option.js
+++ b/test/spec/openapi/option.js
@@ -111,6 +111,56 @@ test('openapi components', async (t) => {
   delete openapiOption.openapi.components.schemas // remove what we just added
 })
 
+test('openapi paths', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  openapiOption.openapi.paths = {
+    '/status': {
+      get: {
+        description: 'Status route, so we can check if server is alive',
+        tags: [
+          'Status'
+        ],
+        responses: {
+          200: {
+            description: 'Server is alive',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    health: {
+                      type: 'boolean'
+                    },
+                    date: {
+                      type: 'string'
+                    }
+                  },
+                  example: {
+                    health: true,
+                    date: '2018-02-19T15:36:46.758Z'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  fastify.get('/status', () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  t.same(openapiObject.paths, openapiOption.openapi.paths)
+  delete openapiOption.openapi.paths // remove what we just added
+})
+
 test('hide support when property set in transform() - property', async (t) => {
   t.plan(1)
   const fastify = Fastify()

--- a/test/spec/swagger/option.js
+++ b/test/spec/swagger/option.js
@@ -99,6 +99,54 @@ test('swagger definitions', async (t) => {
   delete swaggerOption.swagger.definitions // remove what we just added
 })
 
+test('swagger paths', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  swaggerOption.swagger.paths = {
+    '/status': {
+      get: {
+        description: 'Status route, so we can check if server is alive',
+        tags: [
+          'Status'
+        ],
+        responses: {
+          200: {
+            description: 'Server is alive',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    health: {
+                      type: 'boolean'
+                    },
+                    date: {
+                      type: 'string'
+                    }
+                  },
+                  example: {
+                    health: true,
+                    date: '2018-02-19T15:36:46.758Z'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  await fastify.register(fastifySwagger, swaggerOption)
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  t.same(swaggerObject.paths, swaggerOption.swagger.paths)
+  delete swaggerOption.swagger.paths // remove what we just added
+})
+
 test('swagger tags', async (t) => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
Hello! I've started using this plugin and noticed some unexpected behavior while trying to use `openapi` config on `fastify.register`. I've tried to include `openapi.paths` config following your [options documentation](https://github.com/fastify/fastify-swagger#options) ([OpenAPI configuration](https://swagger.io/specification/#oasObject)) in order to include some additional paths to my Swagger object, but it had no effect. This PR fixes it.

Here's an example of what I'm trying to do with `openapi.paths`:
```js
await fastify.register(fastifySwagger, {
  prefix: '/docs',
  openapi: {
    info: {
      title: 'Fastify sample server',
      description: 'Fastify sample api',
      version: '0.1.0',
    },
    paths: {
      '/status': {
        get: {
          description: 'Status route, so we can check if server is alive',
          tags: [
            'Status',
          ],
          responses: {
            200: {
              description: 'Server is alive',
              content: {
                'application/json': {
                  schema: {
                    type: 'object',
                    properties: {
                      health: {
                        type: 'boolean',
                      },
                      date: {
                        type: 'string',
                      },
                    },
                    example: {
                      health: true,
                      date: '2018-02-19T15:36:46.758Z',
                    },
                  },
                },
              },
            },
          },
        },
      },
    },
  },
})
```

I've also fixed it in `swagger` part since [Swagger configuration](https://swagger.io/specification/v2/#swaggerObject) also accepts a `paths` object. 

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
