### PR TITLE
fix(openapi): hide auth header when set in securityScheme

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -52,11 +52,16 @@ const openapiOption = {
           type: 'apiKey',
           name: 'apiKey',
           in: 'header'
+        },
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer'
         }
       }
     },
     security: [{
-      apiKey: []
+      apiKey: [],
+      bearerAuth: []
     }],
     externalDocs: {
       description: 'Find more info here',

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -373,7 +373,10 @@ function prepareOpenapiMethod (schema, ref, openapiObject, url) {
   ]
     .reduce((acc, securitySchemeGroup) => {
       Object.keys(securitySchemeGroup).forEach((securitySchemeLabel) => {
-        const { name, in: category } = openapiObject.components.securitySchemes[securitySchemeLabel]
+        const scheme = openapiObject.components.securitySchemes[securitySchemeLabel]
+        const isBearer = scheme.type === 'http' && scheme.scheme === 'bearer'
+        const category = isBearer ? 'header' : scheme.in
+        const name = isBearer ? 'authorization' : scheme.name
         if (!acc[category]) {
           acc[category] = []
         }

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -647,6 +647,10 @@ test('security headers ignored when declared in security and securityScheme', as
             type: 'string',
             description: 'api token'
           },
+          bearerAuth: {
+            type: 'string',
+            description: 'authorization bearer'
+          },
           id: {
             type: 'string',
             description: 'common field'


### PR DESCRIPTION
Treat the `http` `bearer` auth security scheme the same as other security schemes by removing the `authorization` header.

Fixes #734

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` <== `benchmark` doesn't exist so skipped that one.
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added <== N/A
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
