### PR TITLE
fix: * param renamed to wildcard

### DIFF
--- a/lib/util/format-param-url.js
+++ b/lib/util/format-param-url.js
@@ -65,9 +65,9 @@ function formatParamUrl (str) {
           state = 'regexp'
           level++
         } else if (char === '*') {
-          // * -> wildcard
+          // * -> {*}
           // should be exist once only
-          path += '{wildcard}'
+          path += '{*}'
         } else {
           path += char
         }

--- a/test/util.js
+++ b/test/util.js
@@ -10,7 +10,7 @@ const cases = [
   ['/example/:userId/:secretToken', '/example/{userId}/{secretToken}'],
   ['/example/near/:lat-:lng/radius/:r', '/example/near/{lat}-{lng}/radius/{r}'],
   ['/example/near/:lat_1-:lng_1/radius/:r_1', '/example/near/{lat_1}-{lng_1}/radius/{r_1}'],
-  ['/example/*', '/example/{wildcard}'],
+  ['/example/*', '/example/{*}'],
   ['/example/:file(^\\d+).png', '/example/{file}.png'],
   ['/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', '/example/at/{hour}h{minute}m'],
   ['/example/at/(^\\d{2})h(^\\d{2})m', '/example/at/{regexp1}h{regexp2}m'],


### PR DESCRIPTION
This plugin transforms the route "/example/*" into "/example/{wildcard}". Therefore, the schema for a route with a wildcard should be defined as follows:

```javascript
fastify.get(
  "/example/*",
  {
    schema: {
      params: {
        wildcard: { type: "string" },
      },
    },
  },
  (request, reply) => {
    const path = request.params["*"];
    reply.send(path);
  }
);
```

This pull request allows defining the schema for a route with a wildcard as expected:

```javascript
fastify.get(
  "/example/*",
  {
    schema: {
      params: {
        "*": { type: "string" },
      },
    },
  },
  (request, reply) => {
    const path = request.params["*"];
    reply.send(path);
  }
);
```

This resolves the issue discussed in [this GitHub issue](https://github.com/fastify/fastify-swagger/issues/773).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
