### PR TITLE
docs: Using autoloader for swagger is fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ fastify.swagger()
 <a name="usage.fastify.autoload"></a>
 ### With `@fastify/autoload`
 
-You need to register `@fastify/swagger` before registering `@fastify/autoload`.
+You need to register `@fastify/swagger` before registering routes.
 
 ```js
 const fastify = require('fastify')()


### PR DESCRIPTION
Replace:
> You need to register `@fastify/swagger` before registering `@fastify/autoload`.

By:

> You need to register `@fastify/swagger` before registering routes.