### PR TITLE
feat(openapi): add support for callbacks

### DIFF
--- a/examples/dynamic-openapi.js
+++ b/examples/dynamic-openapi.js
@@ -110,6 +110,59 @@ fastify.register(async function (fastify) {
       }
     }
   }, (req, reply) => { reply.send({ hello: `Hello ${req.body.hello}` }) })
+
+  fastify.post('/subscribe', {
+    schema: {
+      description: 'subscribe for webhooks',
+      summary: 'webhook example',
+      security: [],
+      response: {
+        201: {
+          description: 'Succesful response'
+        }
+      },
+      body: {
+        type: 'object',
+        properties: {
+          callbackUrl: {
+            type: 'string',
+            examples: ['https://example.com']
+          }
+        }
+      },
+      callbacks: {
+        myEvent: {
+          '{$request.body#/callbackUrl}': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        message: {
+                          type: 'string',
+                          example: 'Some event happened'
+                        }
+                      },
+                      required: [
+                        'message'
+                      ]
+                    }
+                  }
+                }
+              },
+              responses: {
+                200: {
+                  description: 'Success'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
 })
 
 fastify.listen({ port: 3000 }, err => {

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -372,6 +372,33 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
   return responsesContainer
 }
 
+function resolveCallbacks (schema, ref) {
+  const callbacksContainer = {}
+
+  Object.entries(schema).forEach(([event, eventValue]) => {
+    callbacksContainer[event] = {}
+
+    Object.entries(eventValue).forEach(([callbackUrl, callbackUrlValue]) => {
+      callbacksContainer[event][callbackUrl] = {}
+
+      Object.entries(callbackUrlValue).forEach(([httpMethod, httpMethodValue]) => {
+        callbacksContainer[event][callbackUrl][httpMethod] = {}
+
+        if (httpMethodValue.requestBody) {
+          callbacksContainer[event][callbackUrl][httpMethod].requestBody = convertJsonSchemaToOpenapi3(ref.resolve(httpMethodValue.requestBody))
+        }
+
+        // at least one callback response is required
+        callbacksContainer[event][callbackUrl][httpMethod].responses = httpMethodValue.responses
+          ? convertJsonSchemaToOpenapi3(ref.resolve(httpMethodValue.responses))
+          : { '2XX': { description: 'Default Response' } }
+      })
+    })
+  })
+
+  return callbacksContainer
+}
+
 function prepareOpenapiMethod (schema, ref, openapiObject, url) {
   const openapiMethod = {}
   const parameters = []
@@ -416,6 +443,7 @@ function prepareOpenapiMethod (schema, ref, openapiObject, url) {
     if (schema.deprecated) openapiMethod.deprecated = schema.deprecated
     if (schema.security) openapiMethod.security = schema.security
     if (schema.servers) openapiMethod.servers = schema.servers
+    if (schema.callbacks) openapiMethod.callbacks = resolveCallbacks(schema.callbacks, ref)
     for (const key of Object.keys(schema)) {
       if (key.startsWith('x-')) {
         openapiMethod[key] = schema[key]

--- a/test/spec/openapi/refs.js
+++ b/test/spec/openapi/refs.js
@@ -355,3 +355,56 @@ test('renders $ref schema with additional keywords', async (t) => {
   t.match(res.statusCode, 400)
   t.match(openapiObject.paths['/url1'].get.parameters[0].schema, cookie)
 })
+
+test('support $ref in callbacks', async (t) => {
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+  fastify.register(async (instance) => {
+    instance.addSchema({ $id: 'Subscription', type: 'object', properties: { callbackUrl: { type: 'string', examples: ['https://example.com'] } } })
+    instance.addSchema({ $id: 'Event', type: 'object', properties: { message: { type: 'string', examples: ['Some event happened'] } } })
+    instance.post('/subscribe', {
+      schema: {
+        body: {
+          $ref: 'Subscription#'
+        },
+        response: {
+          200: {
+            $ref: 'Subscription#'
+          }
+        },
+        callbacks: {
+          myEvent: {
+            '{$request.body#/callbackUrl}': {
+              post: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: 'Event#' }
+                    }
+                  }
+                },
+                responses: {
+                  200: {
+                    description: 'Success'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }, () => {})
+  })
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+
+  t.equal(typeof openapiObject, 'object')
+  t.match(Object.keys(openapiObject.components.schemas), ['Subscription', 'Event'])
+  t.equal(openapiObject.components.schemas.Subscription.properties.callbackUrl.example, 'https://example.com')
+  t.equal(openapiObject.components.schemas.Event.properties.message.example, 'Some event happened')
+
+  await Swagger.validate(openapiObject)
+})


### PR DESCRIPTION
Add support for callbacks in OpenAPI v3 solving https://github.com/fastify/fastify-swagger/issues/727

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
