### PR TITLE
fix (types): changed document type to a discriminating union

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,19 +58,24 @@ declare module 'fastify' {
   }
 }
 
+type SwaggerDocumentObject = {
+  swaggerObject: Partial<OpenAPIV2.Document>;
+} | {
+  openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>;
+}
+
 type SwaggerTransform = <S extends FastifySchema = FastifySchema>({
   schema,
   url,
   route,
-  swaggerObject,
-  openapiObject,
+  ...documentObject
 }: {
   schema: S;
   url: string;
   route: RouteOptions;
-  swaggerObject: Partial<OpenAPIV2.Document>;
-  openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>;
-}) => { schema: FastifySchema; url: string }
+} & SwaggerDocumentObject) => { schema: FastifySchema; url: string }
+
+type SwaggerTransformObject = (documentObject: SwaggerDocumentObject) => Partial<OpenAPIV2.Document> | Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>;
 
 type FastifySwagger = FastifyPluginCallback<fastifySwagger.SwaggerOptions>
 
@@ -147,10 +152,7 @@ declare namespace fastifySwagger {
     /**
      * custom function to transform the openapi or swagger object before it is rendered
      */
-    transformObject?: ({ swaggerObject, openapiObject }: {
-      swaggerObject: Partial<OpenAPIV2.Document>;
-      openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>;
-    }) => Partial<OpenAPIV2.Document> | Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>;
+    transformObject?: SwaggerTransformObject;
 
     refResolver?: {
       /** Clone the input schema without changing it. Default to `false`. */

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -220,16 +220,12 @@ app.get(
         schema,
         url,
         route,
-        swaggerObject,
-        openapiObject,
+        ...documentObject
       }) => {
         schema satisfies FastifySchema;
         url satisfies string;
         route satisfies RouteOptions;
-        swaggerObject satisfies Partial<OpenAPIV2.Document>;
-        openapiObject satisfies Partial<
-          OpenAPIV3.Document | OpenAPIV3_1.Document
-        >;
+        documentObject satisfies { swaggerObject: Partial<OpenAPIV2.Document> } | { openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document> };
         return { schema, url };
       },
     },


### PR DESCRIPTION
I changed the type of openapiObject and swaggerObject to be a discriminating union as it is used in the .js files.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
