### PR TITLE
corrected fastify autoload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,19 @@ fastify.swagger()
 You need to register `@fastify/swagger` before registering routes.
 
 ```js
-const fastify = require('fastify')()
-const fastify = fastify()
-await fastify.register(require('@fastify/swagger'))
-fastify.register(require("@fastify/autoload"), {
-  dir: path.join(__dirname, 'routes')
-})
-await fastify.ready()
-fastify.swagger()
+
+const app = async () => {
+  // ...
+
+  fastify.register(require('@fastify/swagger'))
+
+  // load your routes
+  fastify.register(require("@fastify/autoload"), {
+    dir: path.join(__dirname, 'routes')
+  })
+
+  // ...
+}
 ```
 
 <a name="api"></a>


### PR DESCRIPTION
This pull request is to correct the fastify autoload example . While trying out I noted that calling
```js
await fastify.ready()
fastify.swagger()
```
was not needed

#### Checklist
- [X] documentation is changed or added
