### PR TITLE
fix: multiple alternative security objects in route schema

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -281,6 +281,15 @@ const schemaSecurity = {
   }
 }
 
+const schemaSecurityMultipleAlterntives = {
+  schema: {
+    security: [
+      { apiKey: [] },
+      { bearerAuth: [] }
+    ]
+  }
+}
+
 const schemaConsumes = {
   schema: {
     consumes: ['application/x-www-form-urlencoded'],
@@ -376,6 +385,7 @@ module.exports = {
   schemaHeaders,
   schemaHeadersParams,
   schemaSecurity,
+  schemaSecurityMultipleAlterntives,
   schemaConsumes,
   schemaProduces,
   schemaCookies,

--- a/examples/options.js
+++ b/examples/options.js
@@ -23,6 +23,9 @@ const swaggerOption = {
         type: 'apiKey',
         name: 'apiKey',
         in: 'header'
+      },
+      basicAuth: {
+        type: 'basic'
       }
     },
     security: [{
@@ -281,11 +284,20 @@ const schemaSecurity = {
   }
 }
 
-const schemaSecurityMultipleAlterntives = {
+const schemaOpenapiSecurityMultipleAlterntives = {
   schema: {
     security: [
       { apiKey: [] },
       { bearerAuth: [] }
+    ]
+  }
+}
+
+const schemaSwaggerSecurityMultipleAlterntives = {
+  schema: {
+    security: [
+      { apiKey: [] },
+      { basicAuth: [] }
     ]
   }
 }
@@ -385,7 +397,8 @@ module.exports = {
   schemaHeaders,
   schemaHeadersParams,
   schemaSecurity,
-  schemaSecurityMultipleAlterntives,
+  schemaOpenapiSecurityMultipleAlterntives,
+  schemaSwaggerSecurityMultipleAlterntives,
   schemaConsumes,
   schemaProduces,
   schemaCookies,

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare module 'fastify' {
     consumes?: readonly string[];
     produces?: readonly string[];
     externalDocs?: OpenAPIV2.ExternalDocumentationObject | OpenAPIV3.ExternalDocumentationObject;
-    security?: ReadonlyArray<{ [securityLabel: string]: readonly string[] }>;
+    security?: ReadonlyArray<{ [securityLabel: string]: (readonly string[] | undefined) }>;
     /**
      * OpenAPI operation unique identifier
      */
@@ -52,7 +52,7 @@ declare module 'fastify' {
       [statusCode: string]: OpenAPIV3.ResponseObject['links'];
     }
   }
-  
+
   interface FastifyContextConfig {
     swaggerTransform?: SwaggerTransform | false;
   }

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -817,7 +817,7 @@ test('security headers ignored when declared in multiple required security objec
           }
         }
       },
-      security: [{ apiKey: [] }, { securityKey: [] }]
+      security: [{ apiKey: [], securityKey: [] }]
     }
   })
 

--- a/test/spec/openapi/route.js
+++ b/test/spec/openapi/route.js
@@ -18,7 +18,7 @@ const {
   schemaProduces,
   schemaQuerystring,
   schemaSecurity,
-  schemaSecurityMultipleAlterntives,
+  schemaOpenapiSecurityMultipleAlterntives,
   schemaOperationId
 } = require('../../../examples/options')
 
@@ -36,7 +36,7 @@ test('openapi should return a valid swagger object', async (t) => {
   fastify.get('/headers', schemaHeaders, () => {})
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
-  fastify.get('/securityMultipleAlternatives', schemaSecurityMultipleAlterntives, () => {})
+  fastify.get('/securityMultipleAlternatives', schemaOpenapiSecurityMultipleAlterntives, () => {})
 
   await fastify.ready()
 
@@ -61,7 +61,7 @@ test('openapi should return a valid swagger yaml', async (t) => {
   fastify.get('/headers', schemaHeaders, () => {})
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
-  fastify.get('/securityMultipleAlternatives', schemaSecurityMultipleAlterntives, () => {})
+  fastify.get('/securityMultipleAlternatives', schemaOpenapiSecurityMultipleAlterntives, () => {})
 
   await fastify.ready()
 
@@ -729,7 +729,7 @@ test('security headers ignored when declared in multiple alternative security ob
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -751,7 +751,7 @@ test('security headers ignored when declared in multiple alternative security ob
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -832,7 +832,7 @@ test('security headers ignored when declared in multiple required security objec
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -854,7 +854,7 @@ test('security headers ignored when declared in multiple required security objec
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1005,7 +1005,7 @@ test('security querystrings ignored when declared in multiple alternative securi
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1027,7 +1027,7 @@ test('security querystrings ignored when declared in multiple alternative securi
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1108,7 +1108,7 @@ test('security querystrings ignored when declared in multiple required security 
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1130,7 +1130,7 @@ test('security querystrings ignored when declared in multiple required security 
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1281,7 +1281,7 @@ test('security cookies ignored when declared in multiple alternative security ob
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1303,7 +1303,7 @@ test('security cookies ignored when declared in multiple alternative security ob
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1384,7 +1384,7 @@ test('security cookies ignored when declared in multiple required security objec
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',
@@ -1406,7 +1406,7 @@ test('security cookies ignored when declared in multiple required security objec
           },
           securityKey: {
             type: 'string',
-            description: 'authorization bearer'
+            description: 'security api token'
           },
           id: {
             type: 'string',

--- a/test/spec/swagger/route.js
+++ b/test/spec/swagger/route.js
@@ -14,7 +14,8 @@ const {
   schemaHeadersParams,
   schemaParams,
   schemaQuerystring,
-  schemaSecurity
+  schemaSecurity,
+  schemaSwaggerSecurityMultipleAlterntives
 } = require('../../../examples/options')
 
 test('swagger should return valid swagger object', async (t) => {
@@ -31,6 +32,7 @@ test('swagger should return valid swagger object', async (t) => {
   fastify.get('/headers', schemaHeaders, () => {})
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
+  fastify.get('/securityMultipleAlternatives', schemaSwaggerSecurityMultipleAlterntives, () => {})
 
   await fastify.ready()
 
@@ -59,6 +61,7 @@ test('swagger should return a valid swagger yaml', async (t) => {
   fastify.get('/headers', schemaHeaders, () => {})
   fastify.get('/headers/:id', schemaHeadersParams, () => {})
   fastify.get('/security', schemaSecurity, () => {})
+  fastify.get('/securityMultipleAlternatives', schemaSwaggerSecurityMultipleAlterntives, () => {})
 
   await fastify.ready()
 
@@ -476,6 +479,248 @@ test('security headers ignored when declared in security and securityScheme', as
   t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
+test('security headers ignored when declared in multiple alternative security objects', async (t) => {
+  t.plan(10)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    swagger: {
+      securityDefinitions: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'header'
+        },
+        securityKey: {
+          type: 'apiKey',
+          name: 'securityKey',
+          in: 'header'
+        }
+      },
+      security: [
+        { apiKey: [] }, { securityKey: [] }
+      ]
+    }
+  })
+
+  fastify.get('/address1/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address3/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
+
+  const api = await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+  t.notOk(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+})
+
+test('security headers ignored when declared in multiple required security objects', async (t) => {
+  t.plan(10)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    swagger: {
+      securityDefinitions: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'header'
+        },
+        securityKey: {
+          type: 'apiKey',
+          name: 'securityKey',
+          in: 'header'
+        }
+      },
+      security: [
+        { apiKey: [], securityKey: [] }
+      ]
+    }
+  })
+
+  fastify.get('/address1/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address3/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      headers: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
+
+  const api = await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+  t.notOk(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+})
+
 test('security querystrings ignored when declared in security and securityScheme', async (t) => {
   t.plan(6)
   const fastify = Fastify()
@@ -554,6 +799,127 @@ test('security querystrings ignored when declared in security and securityScheme
   t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'somethingElse')))
   t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
   t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+})
+
+test('security querystrings ignored when declared in multiple alternative security objects', async (t) => {
+  t.plan(10)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, {
+    swagger: {
+      securityDefinitions: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'query'
+        },
+        securityKey: {
+          type: 'apiKey',
+          name: 'securityKey',
+          in: 'query'
+        }
+      },
+      security: [
+        { apiKey: [] }, { securityKey: [] }
+      ]
+    }
+  })
+
+  fastify.get('/address1/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          apiKey: {
+            type: 'string',
+            description: 'api token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address2/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          securityKey: {
+            type: 'string',
+            description: 'security api token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  fastify.get('/address3/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          authKey: {
+            type: 'string',
+            description: 'auth token'
+          },
+          somethingElse: {
+            type: 'string',
+            description: 'common field'
+          }
+        }
+      }
+    }
+  }, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  t.equal(typeof swaggerObject, 'object')
+
+  const api = await Swagger.validate(swaggerObject)
+  t.pass('valid swagger object')
+  t.ok(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'apiKey')))
+  t.notOk(api.paths['/address1/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
+  t.notOk(api.paths['/address2/{id}'].get.parameters.find(({ name }) => (name === 'securityKey')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'id')))
+  t.ok(api.paths['/address3/{id}'].get.parameters.find(({ name }) => (name === 'authKey')))
 })
 
 test('verify generated path param definition with route prefixing', async (t) => {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -125,6 +125,53 @@ app.get('/public/readonly-schema-route', {
     }
   } as const, (req, reply) => {});
 
+app.register(fastifySwagger, {
+  openapi: {
+    info: {
+      title: "Test openapi",
+      description: "testing multiple security schemes",
+      version: "1.0.0"
+    },
+    components: {
+      securitySchemes: {
+        aapiKey: {
+          type: "apiKey",
+          name: "apiKey",
+          in: "header",
+        },
+        abearerToken: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+    security: [],
+  },
+  mode: 'dynamic',
+});
+
+app.get('/multiple/security/and', {
+  schema: {
+      security: [{ apiKey: [], bearerToken: [] }],
+      response: { 200: {} },
+  },
+}, () => {});
+
+app.get('/multiple/security/or', {
+  schema: {
+      security: [{ apiKey: [] }, { bearerToken: [] }],
+      response: { 200: {} },
+  },
+}, () => {});
+
+app.get('/multiple/security/or/alternative', {
+  schema: {
+      security: [{ apiKey: [], bearerToken: undefined }, { bearerToken: [], apiKey: undefined }],
+      response: { 200: {} },
+  },
+}, () => {});
+
 app
   .register(fastifySwagger, {
     swagger: {


### PR DESCRIPTION
Fixes #816

Update the `security` property of `FastifySchema` to allow multiple security objects in a route schema.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
