### PR TITLE
feat: support multiple content type schemas per request body

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -263,21 +263,28 @@ function schemaToMediaRecursive (schema) {
 
 function resolveBodyParams (body, schema, consumes, ref) {
   const resolved = convertJsonSchemaToOpenapi3(ref.resolve(schema))
-  if ((Array.isArray(consumes) && consumes.length === 0) || consumes === undefined) {
-    consumes = ['application/json']
-  }
 
-  const media = schemaToMediaRecursive(resolved)
-  consumes.forEach((consume) => {
-    body.content[consume] = media
-  })
+  if (resolved.content && resolved.content[Object.keys(resolved.content)[0]].schema) {
+    for (const contentType in schema.content) {
+      body.content[contentType] = schemaToMediaRecursive(resolved.content[contentType].schema)
+    }
+  } else {
+    if ((Array.isArray(consumes) && consumes.length === 0) || consumes === undefined) {
+      consumes = ['application/json']
+    }
 
-  if (resolved && resolved.required && resolved.required.length) {
-    body.required = true
-  }
+    const media = schemaToMediaRecursive(resolved)
+    consumes.forEach((consume) => {
+      body.content[consume] = media
+    })
 
-  if (resolved && resolved.description) {
-    body.description = resolved.description
+    if (resolved && resolved.required && resolved.required.length) {
+      body.required = true
+    }
+
+    if (resolved && resolved.description) {
+      body.description = resolved.description
+    }
   }
 }
 

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -1034,3 +1034,70 @@ test('avoid overwriting params when schema.params is provided', async t => {
     }
   })
 })
+
+test('support multiple content types as request', async t => {
+  const opt = {
+    schema: {
+      body: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                jsonProperty: {
+                  type: 'string'
+                }
+              }
+            }
+          },
+          'application/xml': {
+            schema: {
+              type: 'object',
+              properties: {
+                xmlProperty: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, {
+    openapi: true
+  })
+  fastify.post('/', opt, () => { })
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].post
+  t.match(definedPath.requestBody, {
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            jsonProperty: {
+              type: 'string'
+            }
+          }
+        }
+      },
+      'application/xml': {
+        schema: {
+          type: 'object',
+          properties: {
+            xmlProperty: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
Handle different schemas per content type specified in the request body after Fastify added support for it in [fastify/fastify#5545](https://github.com/fastify/fastify/pull/5545)

Specifying more than one schema generated an incorrect OpenAPI spec:
```json
{
  // ...
  "requestBody":{
    "content":{
      "application/json":{
        "schema":{
          "content":{
            "application/json":{
              "schema": {
                // ...
              }
            },
            "application/xml":{
              "schema": {
                // ...
              }
            }
            // ...
          }
        }
      }
    }
  }
}
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
