### PR TITLE
Fix #821: incorrect reference when using $ref in patternProperties

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -475,7 +475,9 @@ function convertJsonSchemaToOpenapi3 (jsonSchema) {
       // TODO: this breaks references to the additionalProperties properties
       // TODO: patternProperties actually allowed in the openapi schema, but should
       // always start with "x-" prefix
-      openapiSchema.additionalProperties = Object.values(openapiSchema.patternProperties)[0]
+      const propertyJsonSchema = Object.values(openapiSchema.patternProperties)[0]
+      const propertyOpenapiSchema = convertJsonSchemaToOpenapi3(propertyJsonSchema)
+      openapiSchema.additionalProperties = propertyOpenapiSchema
       delete openapiSchema.patternProperties
       continue
     }


### PR DESCRIPTION
Fixes the incorrect reference when using $ref in patternProperties as described in [#821](https://github.com/fastify/fastify-swagger/issues/821).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
