### PR TITLE
docs: Fallback to reference description for responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ fastify.get('/responseDescription', {
   }
 }, () => {})
 ```
+
+Additionally, if you provide a `$ref` in your response schema but no description, the reference's description will be used as a fallback.
+
 <a name="route.response.2xx"></a>
 ##### Status code 2xx
 Fastify supports both the `2xx` and `3xx` status codes, however Swagger (OpenAPI v2) itself does not.

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ fastify.get('/responseDescription', {
 }, () => {})
 ```
 
-Additionally, if you provide a `$ref` in your response schema but no description, the reference's description will be used as a fallback. Note that at the moment, `$ref` will only be resolved by matching with `$id` and not through complex paths. Currently being addressed in [this Pull Request](https://github.com/fastify/fastify-swagger/pull/676).
+Additionally, if you provide a `$ref` in your response schema but no description, the reference's description will be used as a fallback. Note that at the moment, `$ref` will only be resolved by matching with `$id` and not through complex paths.
 
 <a name="route.response.2xx"></a>
 ##### Status code 2xx

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ fastify.get('/responseDescription', {
 }, () => {})
 ```
 
-Additionally, if you provide a `$ref` in your response schema but no description, the reference's description will be used as a fallback.
+Additionally, if you provide a `$ref` in your response schema but no description, the reference's description will be used as a fallback. Note that at the moment, `$ref` will only be resolved by matching with `$id` and not through complex paths. Currently being addressed in [this Pull Request](https://github.com/fastify/fastify-swagger/pull/676).
 
 <a name="route.response.2xx"></a>
 ##### Status code 2xx

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -3,6 +3,7 @@
 const { readPackageJson } = require('../../util/read-package-json')
 const { formatParamUrl } = require('../../util/format-param-url')
 const { resolveLocalRef } = require('../../util/resolve-local-ref')
+const { resolveSchemaReference } = require('../../util/resolve-schema-reference')
 const { xResponseDescription, xConsume, xExamples } = require('../../constants')
 const { rawRequired } = require('../../symbols')
 const { generateParamsSchema } = require('../../util/generate-params-schema')
@@ -303,6 +304,11 @@ function resolveCommonParams (container, parameters, schema, ref, sharedSchemas,
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }
 
+function findReferenceDescription (rawSchema, ref) {
+  const resolved = resolveSchemaReference(rawSchema, ref)
+  return resolved?.description
+}
+
 // https://swagger.io/docs/specification/describing-responses/
 function resolveResponse (fastifyResponseJson, produces, ref) {
   // if the user does not provided an out schema
@@ -327,7 +333,10 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
     }
 
     const response = {
-      description: resolved[xResponseDescription] || rawJsonSchema.description || 'Default Response'
+      description: resolved[xResponseDescription] ||
+        rawJsonSchema.description ||
+        findReferenceDescription(rawJsonSchema, ref) ||
+        'Default Response'
     }
 
     // add headers when there are any.

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -3,6 +3,7 @@
 const { readPackageJson } = require('../../util/read-package-json')
 const { formatParamUrl } = require('../../util/format-param-url')
 const { resolveLocalRef } = require('../../util/resolve-local-ref')
+const { resolveSchemaReference } = require('../../util/resolve-schema-reference')
 const { xResponseDescription, xConsume } = require('../../constants')
 const { generateParamsSchema } = require('../../util/generate-params-schema')
 const { hasParams } = require('../../util/match-params')
@@ -205,6 +206,11 @@ function resolveCommonParams (container, parameters, schema, ref, sharedSchemas,
   arr.forEach(swaggerSchema => parameters.push(swaggerSchema))
 }
 
+function findReferenceDescription (rawSchema, ref) {
+  const resolved = resolveSchemaReference(rawSchema, ref)
+  return resolved?.description
+}
+
 // https://swagger.io/docs/specification/2-0/describing-responses/
 function resolveResponse (fastifyResponseJson, ref) {
   // if the user does not provided an out schema
@@ -235,7 +241,10 @@ function resolveResponse (fastifyResponseJson, ref) {
     }
 
     const response = {
-      description: rawJsonSchema[xResponseDescription] || rawJsonSchema.description || 'Default Response'
+      description: rawJsonSchema[xResponseDescription] ||
+        rawJsonSchema.description ||
+        findReferenceDescription(rawJsonSchema, ref) ||
+        'Default Response'
     }
 
     // add headers when there are any.

--- a/lib/util/resolve-schema-reference.js
+++ b/lib/util/resolve-schema-reference.js
@@ -4,7 +4,7 @@ function resolveSchemaReference (rawSchema, ref) {
   const resolvedReference = ref.resolve(rawSchema, { externalSchemas: [ref.definitions().definitions] })
 
   // Ref has format `#/definitions/id`
-  const schemaId = resolvedReference?.$ref?.split('/')[2]
+  const schemaId = resolvedReference?.$ref?.split('/', 3)[2]
 
   if (schemaId === undefined) {
     return undefined

--- a/lib/util/resolve-schema-reference.js
+++ b/lib/util/resolve-schema-reference.js
@@ -1,0 +1,18 @@
+'use strict'
+
+function resolveSchemaReference (rawSchema, ref) {
+  const resolvedReference = ref.resolve(rawSchema, { externalSchemas: [ref.definitions().definitions] })
+
+  // Ref has format `#/definitions/id`
+  const schemaId = resolvedReference?.$ref?.split('/')[2]
+
+  if (schemaId === undefined) {
+    return undefined
+  }
+
+  return resolvedReference.definitions[schemaId]
+}
+
+module.exports = {
+  resolveSchemaReference
+}

--- a/test/spec/swagger/schema.js
+++ b/test/spec/swagger/schema.js
@@ -69,6 +69,36 @@ test('support response description', async t => {
   t.same(definedPath.responses['200'].description, 'Response OK!')
 })
 
+test('support response description fallback to its $ref', async t => {
+  const opts = {
+    schema: {
+      response: {
+        200: {
+          $ref: 'my-ref#'
+        }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  fastify.addSchema({
+    $id: 'my-ref',
+    description: 'Response OK!',
+    type: 'string'
+  })
+
+  await fastify.register(fastifySwagger)
+  fastify.get('/', opts, () => {})
+
+  await fastify.ready()
+
+  const swaggerObject = fastify.swagger()
+  const api = await Swagger.validate(swaggerObject)
+
+  const definedPath = api.paths['/'].get
+  t.same(definedPath.responses['200'].description, 'Response OK!')
+})
+
 test('response default description', async t => {
   const opts9 = {
     schema: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR attempts to resolve the issue on https://github.com/fastify/fastify-swagger/issues/795 by resolving the `$ref` given in the schema and fetching that description in case there's none. PTAL! 🚀 