### PR TITLE
feat(openapi): add support for callbacks

### DIFF
--- a/examples/dynamic-openapi.js
+++ b/examples/dynamic-openapi.js
@@ -112,6 +112,59 @@ fastify.register(async function (fastify) {
   }, (req, reply) => { reply.send({ hello: `Hello ${req.body.hello}` }) })
 })
 
+fastify.post('/subscribe', {
+  schema: {
+    description: 'subscribe for webhooks',
+    summary: 'webhook example',
+    security: [],
+    response: {
+      201: {
+        description: 'Succesful response'
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        callbackUrl: {
+          type: 'string',
+          examples: ['https://example.com']
+        }
+      }
+    },
+    callbacks: {
+      myEvent: {
+        '{$request.body#/callbackUrl}': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      message: {
+                        type: 'string',
+                        example: 'Some event happened'
+                      }
+                    },
+                    required: [
+                      'message'
+                    ]
+                  }
+                }
+              }
+            },
+            responses: {
+              200: {
+                description: 'Success'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
 fastify.listen({ port: 3000 }, err => {
   if (err) throw err
 })

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -388,6 +388,51 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
   return responsesContainer
 }
 
+function resolveCallbacks (schema, ref) {
+  const callbacksContainer = {}
+
+  for (const eventName in schema) {
+    if (!schema[eventName]) {
+      continue
+    }
+
+    const eventSchema = schema[eventName]
+    const [callbackUrl] = Object.keys(eventSchema)
+
+    if (!callbackUrl || !eventSchema[callbackUrl]) {
+      continue
+    }
+
+    const callbackSchema = schema[eventName][callbackUrl]
+    const [httpMethodName] = Object.keys(callbackSchema)
+
+    if (!httpMethodName || !callbackSchema[httpMethodName]) {
+      continue
+    }
+
+    const httpMethodSchema = callbackSchema[httpMethodName]
+    const httpMethodContainer = {}
+
+    if (httpMethodSchema.requestBody) {
+      httpMethodContainer.requestBody = convertJsonSchemaToOpenapi3(
+        ref.resolve(httpMethodSchema.requestBody)
+      )
+    }
+
+    httpMethodContainer.responses = httpMethodSchema.responses
+      ? convertJsonSchemaToOpenapi3(ref.resolve(httpMethodSchema.responses))
+      : { '2XX': { description: 'Default Response' } }
+
+    callbacksContainer[eventName] = {
+      [callbackUrl]: {
+        [httpMethodName]: httpMethodContainer
+      }
+    }
+  }
+
+  return callbacksContainer
+}
+
 function prepareOpenapiMethod (schema, ref, openapiObject, url) {
   const openapiMethod = {}
   const parameters = []
@@ -432,6 +477,7 @@ function prepareOpenapiMethod (schema, ref, openapiObject, url) {
     if (schema.deprecated) openapiMethod.deprecated = schema.deprecated
     if (schema.security) openapiMethod.security = schema.security
     if (schema.servers) openapiMethod.servers = schema.servers
+    if (schema.callbacks) openapiMethod.callbacks = resolveCallbacks(schema.callbacks, ref)
     for (const key of Object.keys(schema)) {
       if (key.startsWith('x-')) {
         openapiMethod[key] = schema[key]

--- a/test/spec/openapi/schema.js
+++ b/test/spec/openapi/schema.js
@@ -1136,3 +1136,430 @@ test('support multiple content types as request', async t => {
     }
   })
 })
+
+test('support callbacks', async () => {
+  test('includes callbacks in openapiObject', async t => {
+    const fastify = Fastify()
+
+    await fastify.register(fastifySwagger, openapiOption)
+    fastify.register(async (instance) => {
+      instance.post(
+        '/subscribe',
+        {
+          schema: {
+            body: {
+              $id: 'Subscription',
+              type: 'object',
+              properties: {
+                callbackUrl: {
+                  type: 'string',
+                  examples: ['https://example.com']
+                }
+              }
+            },
+            response: {
+              200: {
+                $id: 'Subscription',
+                type: 'object',
+                properties: {
+                  callbackUrl: {
+                    type: 'string',
+                    examples: ['https://example.com']
+                  }
+                }
+              }
+            },
+            callbacks: {
+              myEvent: {
+                '{$request.body#/callbackUrl}': {
+                  post: {
+                    requestBody: {
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: {
+                              message: {
+                                type: 'string',
+                                example: 'Some event happened'
+                              }
+                            },
+                            required: ['message']
+                          }
+                        }
+                      }
+                    },
+                    responses: {
+                      200: {
+                        description: 'Success'
+                      }
+                    }
+                  }
+                }
+              },
+              myOtherEvent: {
+                '{$request.body#/callbackUrl}': {
+                  post: {
+                    responses: {
+                      200: {
+                        description: 'Success'
+                      },
+                      500: {
+                        description: 'Error'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        () => {}
+      )
+    })
+
+    await fastify.ready()
+
+    const openapiObject = fastify.swagger()
+
+    t.equal(typeof openapiObject, 'object')
+    t.equal(typeof openapiObject.paths['/subscribe'].post.callbacks, 'object')
+
+    const definedPath = openapiObject.paths['/subscribe'].post.callbacks
+
+    t.strictSame(
+      definedPath.myEvent['{$request.body#/callbackUrl}'].post.requestBody
+        .content['application/json'].schema.properties,
+      {
+        message: {
+          type: 'string',
+          example: 'Some event happened'
+        }
+      }
+    )
+
+    t.same(
+      definedPath.myOtherEvent['{$request.body#/callbackUrl}'].post.requestBody,
+      null
+    )
+
+    await Swagger.validate(openapiObject)
+  })
+
+  test('sets callback response default if not included', async t => {
+    const fastify = Fastify()
+
+    await fastify.register(fastifySwagger, openapiOption)
+    fastify.register(async (instance) => {
+      instance.post(
+        '/subscribe',
+        {
+          schema: {
+            body: {
+              $id: 'Subscription',
+              type: 'object',
+              properties: {
+                callbackUrl: {
+                  type: 'string',
+                  examples: ['https://example.com']
+                }
+              }
+            },
+            response: {
+              200: {
+                $id: 'Subscription',
+                type: 'object',
+                properties: {
+                  callbackUrl: {
+                    type: 'string',
+                    examples: ['https://example.com']
+                  }
+                }
+              }
+            },
+            callbacks: {
+              myEvent: {
+                '{$request.body#/callbackUrl}': {
+                  post: {
+                    requestBody: {
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: {
+                              message: {
+                                type: 'string',
+                                example: 'Some event happened'
+                              }
+                            },
+                            required: ['message']
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        () => {}
+      )
+    })
+
+    await fastify.ready()
+
+    const openapiObject = fastify.swagger()
+
+    t.equal(typeof openapiObject, 'object')
+    t.equal(typeof openapiObject.paths['/subscribe'].post.callbacks, 'object')
+
+    const definedPath = openapiObject.paths['/subscribe'].post
+
+    t.equal(
+      definedPath.callbacks.myEvent['{$request.body#/callbackUrl}'].post
+        .responses['2XX'].description,
+      'Default Response'
+    )
+
+    await Swagger.validate(openapiObject)
+  })
+
+  test('skips callbacks if badly formatted', async t => {
+    const fastify = Fastify()
+
+    await fastify.register(fastifySwagger, openapiOption)
+    fastify.register(async (instance) => {
+      instance.post(
+        '/subscribe',
+        {
+          schema: {
+            body: {
+              $id: 'Subscription',
+              type: 'object',
+              properties: {
+                callbackUrl: {
+                  type: 'string',
+                  examples: ['https://example.com']
+                }
+              }
+            },
+            response: {
+              200: {
+                $id: 'Subscription',
+                type: 'object',
+                properties: {
+                  callbackUrl: {
+                    type: 'string',
+                    examples: ['https://example.com']
+                  }
+                }
+              }
+            },
+            callbacks: {
+              myEvent: null
+            }
+          }
+        },
+        () => {}
+      )
+    })
+
+    await fastify.ready()
+
+    const openapiObject = fastify.swagger()
+
+    t.equal(typeof openapiObject, 'object')
+    t.strictSame(openapiObject.paths['/subscribe'].post.callbacks, {})
+
+    await Swagger.validate(openapiObject)
+  })
+
+  test('skips callback if event is badly formatted', async t => {
+    const fastify = Fastify()
+
+    await fastify.register(fastifySwagger, openapiOption)
+    fastify.register(async (instance) => {
+      instance.post(
+        '/subscribe',
+        {
+          schema: {
+            body: {
+              $id: 'Subscription',
+              type: 'object',
+              properties: {
+                callbackUrl: {
+                  type: 'string',
+                  examples: ['https://example.com']
+                }
+              }
+            },
+            response: {
+              200: {
+                $id: 'Subscription',
+                type: 'object',
+                properties: {
+                  callbackUrl: {
+                    type: 'string',
+                    examples: ['https://example.com']
+                  }
+                }
+              }
+            },
+            callbacks: {
+              myEvent: {
+                '{$request.body#/callbackUrl}': {
+                  post: {
+                    requestBody: {
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: {
+                              message: {
+                                type: 'string',
+                                example: 'Some event happened'
+                              }
+                            },
+                            required: ['message']
+                          }
+                        }
+                      }
+                    },
+                    responses: {
+                      200: {
+                        description: 'Success'
+                      }
+                    }
+                  }
+                }
+              },
+              myOtherEvent: {
+                '{$request.body#/callbackUrl}': {}
+              }
+            }
+          }
+        },
+        () => {}
+      )
+    })
+
+    await fastify.ready()
+
+    const openapiObject = fastify.swagger()
+
+    t.equal(typeof openapiObject, 'object')
+    t.equal(typeof openapiObject.paths['/subscribe'].post.callbacks, 'object')
+    t.match(Object.keys(openapiObject.paths['/subscribe'].post.callbacks), [
+      'myEvent'
+    ])
+
+    const definedPath = openapiObject.paths['/subscribe'].post.callbacks
+
+    t.strictSame(
+      definedPath.myEvent['{$request.body#/callbackUrl}'].post.requestBody
+        .content['application/json'].schema.properties,
+      {
+        message: {
+          type: 'string',
+          example: 'Some event happened'
+        }
+      }
+    )
+
+    await Swagger.validate(openapiObject)
+  })
+
+  test('skips callback if method is badly formatted', async t => {
+    const fastify = Fastify()
+
+    await fastify.register(fastifySwagger, openapiOption)
+    fastify.register(async (instance) => {
+      instance.post(
+        '/subscribe',
+        {
+          schema: {
+            body: {
+              $id: 'Subscription',
+              type: 'object',
+              properties: {
+                callbackUrl: {
+                  type: 'string',
+                  examples: ['https://example.com']
+                }
+              }
+            },
+            response: {
+              200: {
+                $id: 'Subscription',
+                type: 'object',
+                properties: {
+                  callbackUrl: {
+                    type: 'string',
+                    examples: ['https://example.com']
+                  }
+                }
+              }
+            },
+            callbacks: {
+              myEvent: {
+                '{$request.body#/callbackUrl}': {
+                  post: {
+                    requestBody: {
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: {
+                              message: {
+                                type: 'string',
+                                example: 'Some event happened'
+                              }
+                            },
+                            required: ['message']
+                          }
+                        }
+                      }
+                    },
+                    responses: {
+                      200: {
+                        description: 'Success'
+                      }
+                    }
+                  }
+                }
+              },
+              myOtherEvent: {}
+            }
+          }
+        },
+        () => {}
+      )
+    })
+
+    await fastify.ready()
+
+    const openapiObject = fastify.swagger()
+
+    t.equal(typeof openapiObject, 'object')
+    t.equal(typeof openapiObject.paths['/subscribe'].post.callbacks, 'object')
+    t.match(Object.keys(openapiObject.paths['/subscribe'].post.callbacks), [
+      'myEvent'
+    ])
+
+    const definedPath = openapiObject.paths['/subscribe'].post.callbacks
+
+    t.strictSame(
+      definedPath.myEvent['{$request.body#/callbackUrl}'].post.requestBody
+        .content['application/json'].schema.properties,
+      {
+        message: {
+          type: 'string',
+          example: 'Some event happened'
+        }
+      }
+    )
+
+    await Swagger.validate(openapiObject)
+  })
+})


### PR DESCRIPTION
Add support for callbacks in OpenAPI v3 solving https://github.com/fastify/fastify-swagger/issues/727

Fork of https://github.com/fastify/fastify-swagger/pull/804 with a flatter approach

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
