### PR TITLE
fix(resolve schema reference): shortcut if definitions is undefined

### DIFF
--- a/lib/util/resolve-schema-reference.js
+++ b/lib/util/resolve-schema-reference.js
@@ -6,7 +6,7 @@ function resolveSchemaReference (rawSchema, ref) {
   // Ref has format `#/definitions/id`
   const schemaId = resolvedReference?.$ref?.split('/', 3)[2]
 
-  if (schemaId === undefined) {
+  if (schemaId === undefined || resolvedReference.definitions === undefined) {
     return undefined
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hello. Firstof, thanks for maintaining this lib 🙇🏻 

It appears [this fix](https://github.com/fastify/fastify-swagger/pull/826/files) is causing an issue with our codebase. We have an endpoints that is is defined like this:

```ts
import type { FastifyInstance, FastifyRegisterOptions } from 'fastify';
import type { FastifyZodOpenApiTypeProvider } from 'fastify-zod-openapi';
import { z } from 'zod';

const myResponseSchema = z
  .object({
     // ...
  })
  .openapi({
    ref: 'MyResponse',
  });

fastifyInstance.withTypeProvider<FastifyZodOpenApiTypeProvider>().route({
    method: 'GET',
    url: '/',
    schema: {
      response: {
        [HTTPStatusCodeEnum.ok]: myResponseSchema
      },
    },
```

which resolves to a schema like this:

```json
{
  "components": {
    "schemas": {
      "MyResponse": {
        "type": "object",
        "properties": {
           // ...
         }
      }
    }
  },
  "paths": {
    "/my-endpoint": {
      "get": {
        "responses": {
          "200": {
            "description": "Default Response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/MyResponse",
                }
              }
            }
          }
        }
      }
    }
  }
}

```

The issue is there is no definitions for this ref, which makes the whole thing crash. Wasn't the case before.
One simple fix is to check if `resolvedReference.definitions` is `undefined` before trying to access it.

I tried to write a test to reproduce the issue but I'm not an openapi expert so I can't seem to get anywhere:

```js
test('should not crash if response has no definitions', async (t) => {
  const fastify = Fastify();

  await fastify.register(fastifySwagger, {
    openapi: {
      components: {
        schemas: {
          MyResponse: {
            type: 'object',
            properties: {},
          },
        },
      },
      paths: {
        '/response-with-ref': {
          get: {
            responses: {
              200: {
                description: 'Default Response',
                content: {
                  'application/json': {
                    schema: {
                      $ref: '#/components/schemas/MyResponse',
                    },
                  },
                },
              },
            },
          },
        },
      },
    },
  });
  fastify.register(async (instance) => {
    instance.get(
      '/response-with-ref',
      {
        schema: {
          response: {
            200: { $ref: '#/components/schemas/MyResponse' },
          },
        },
      },
      () => {}
    );
  });

  await fastify.ready();

  const openapiObject = fastify.swagger();

  t.equal(typeof openapiObject, 'object');

  await Swagger.validate(openapiObject);
});
```

This fails with:

```bash
 ✖should not crash if response has no definitions > Failed building the serialization schema for GET: /response-with-ref, due to errornode_modules/fastify/lib/route.js:
   Cannot find reference "#/components/schemas/MyResponse"                                                                            400:21
```

Any help would be appreciated. Thank you!


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
