### PR TITLE
fix: soft fail fallback response description lookups

### DIFF
--- a/lib/util/resolve-schema-reference.js
+++ b/lib/util/resolve-schema-reference.js
@@ -10,7 +10,7 @@ function resolveSchemaReference (rawSchema, ref) {
     return undefined
   }
 
-  return resolvedReference.definitions[schemaId]
+  return resolvedReference.definitions?.[schemaId]
 }
 
 module.exports = {


### PR DESCRIPTION
I tried fixing this issue in my library as raised in https://github.com/samchungy/fastify-zod-openapi/issues/172 

My library dynamically generates `$ref`s for users so they don't need to register anything upfront and plops them into the components section at the end.

As an example, my users will fill in the following:

```ts
responses: {
  200: z.string().openapi({ ref: 'Foo' })
}
```

The `transform` hook will output:

```ts
responses: {
  200: {
    $ref: '#/components/schemas/Foo'
  }
}
```

I tried dynamically injecting the components in the `transform` hook and even when I tried adding components into the fastifySwagger constructor this seems to not work.

```ts
fastify.register(fastifySwagger, {
    openapi: {
      components: {
		schema: {
		  foo: {
		    type: 'string'
		  }
		}
	}
});
```

This function does not seem to reference openapi components: https://github.com/fastify/fastify-swagger/blob/36a543cef71d32d434e07b610d6f0b233cbd566e/lib/util/resolve-schema-reference.js#L3-L18 and the rest of the code's support for components seem fairly limited.

Additionally this line in particular:
https://github.com/fastify/fastify-swagger/blob/36a543cef71d32d434e07b610d6f0b233cbd566e/lib/util/resolve-schema-reference.js#L7

only returns `schemas`.

I might revisit this repo to add proper openapi component support and start incrementally adding components to the `openapiObject` construct but for now I want to unblock my users.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
