### PR TITLE
feat: Add custom decorator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ To deep down the `buildLocalReference` arguments, you may read the [documentatio
 <a name="register.options.decorator"></a>
 #### Decorator
 
-By passing a string to the `decorator` option, you can override the default decorator function (`fastify.swagger()`) with a custom one. This allows you to create multiple documents by registering fastify-swagger multiple times with different `transform` functions:
+By passing a string to the `decorator` option, you can override the default decorator function (`fastify.swagger()`) with a custom one. This allows you to create multiple documents by registering `@fastify/swagger` multiple times with different `transform` functions:
 
 ```js
 // Create an internal Swagger doc

--- a/README.md
+++ b/README.md
@@ -381,9 +381,10 @@ await fastify.register(require('@fastify/swagger'), {
       response,
       ...transformedSchema
     } = schema
-    let transformedUrl = url
+    let transformedUrl = URL
 
-    if (url.startsWith('/internal')) transformedSchema.hide = true
+    // Hide external URLs
+    if (url.startsWith('/external')) transformedSchema.hide = true
 
     return { schema: transformedSchema, url: transformedUrl }
   },
@@ -402,9 +403,10 @@ await fastify.register(require('@fastify/swagger'), {
       response,
       ...transformedSchema
     } = schema
-    let transformedUrl = url
+    let transformedUrl = URL
 
-    if (url.startsWith('/external')) transformedSchema.hide = true
+    // Hide internal URLs
+    if (url.startsWith('/internal')) transformedSchema.hide = true
 
     return { schema: transformedSchema, url: transformedUrl }
   },

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ await fastify.register(require('@fastify/swagger'), {
   decorator: 'internalSwagger'
 })
 
-// Create an external swagger doc
+// Create an external Swagger doc
 await fastify.register(require('@fastify/swagger'), {
   swagger: { ... },
   transform: ({ schema, url, route, swaggerObject }) => {

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ To deep down the `buildLocalReference` arguments, you may read the [documentatio
 By passing a string to the `decorator` option, you can override the default decorator function (`fastify.swagger()`) with a custom one. This allows you to create multiple documents by registering fastify-swagger multiple times with different `transform` functions:
 
 ```js
-// Create an internal swagger doc
+// Create an internal Swagger doc
 await fastify.register(require('@fastify/swagger'), {
   swagger: { ... },
   transform: ({ schema, url, route, swaggerObject }) => {

--- a/lib/mode/dynamic.js
+++ b/lib/mode/dynamic.js
@@ -13,6 +13,7 @@ module.exports = function (fastify, opts, done) {
     swagger: {},
     transform: null,
     transformObject: null,
+    decorator: 'swagger',
     refResolver: {
       buildLocalReference (json, baseUri, fragment, i) {
         if (!json.title && json.$id) {
@@ -31,7 +32,7 @@ module.exports = function (fastify, opts, done) {
   }
 
   const swagger = resolveSwaggerFunction(opts, cache, routes, Ref, done)
-  fastify.decorate('swagger', swagger)
+  fastify.decorate(opts.decorator, swagger)
 
   done()
 }

--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -56,7 +56,7 @@ module.exports = function (fastify, opts, done) {
     swaggerObject = opts.specification.document
   }
 
-  fastify.decorate('swagger', swagger)
+  fastify.decorate(opts.decorator || 'swagger', swagger)
 
   const cache = {
     swaggerObject: null,

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -41,7 +41,5 @@ test('decorator can be overridden', async (t) => {
   await fastify.register(fastifySwagger, { decorator: 'customSwaggerDecorator' })
 
   await fastify.ready()
-
-  await fastify.ready()
   t.ok(fastify.customSwaggerDecorator())
 })

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -33,3 +33,15 @@ test('fastify.swagger should throw if called before ready (openapi)', async (t) 
 
   t.throws(fastify.swagger.bind(fastify))
 })
+
+test('decorator can be overridden', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, { decorator: 'customSwaggerDecorator' })
+
+  await fastify.ready()
+
+  await fastify.ready()
+  t.ok(fastify.customSwaggerDecorator())
+})


### PR DESCRIPTION
This adds the ability to customize the Fastify decorator while defaulting to the existing `swagger`. This enables generating multiple swagger docs with different `transform` functions, allowing more flexibility for e.g. creating multiple docs based on custom route config options. I believe this solves #631 if the set of user scopes is known ahead of time.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
