### PR TITLE
fix(openapi): support full callbacks spec

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -391,41 +391,48 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
 function resolveCallbacks (schema, ref) {
   const callbacksContainer = {}
 
+  // Iterate over each callback event
   for (const eventName in schema) {
     if (!schema[eventName]) {
       continue
     }
 
+    // Create an empty object to house the future iterations
+    callbacksContainer[eventName] = {}
     const eventSchema = schema[eventName]
-    const [callbackUrl] = Object.keys(eventSchema)
 
-    if (!callbackUrl || !eventSchema[callbackUrl]) {
-      continue
-    }
+    // Iterate over each callbackUrl for the event
+    for (const callbackUrl in eventSchema) {
+      if (!callbackUrl || !eventSchema[callbackUrl]) {
+        continue
+      }
 
-    const callbackSchema = schema[eventName][callbackUrl]
-    const [httpMethodName] = Object.keys(callbackSchema)
+      // Create an empty object to house the future iterations
+      callbacksContainer[eventName][callbackUrl] = {}
+      const callbackSchema = eventSchema[callbackUrl]
 
-    if (!httpMethodName || !callbackSchema[httpMethodName]) {
-      continue
-    }
+      // Iterate over each httpMethod for the callbackUrl
+      for (const httpMethodName in callbackSchema) {
+        if (!httpMethodName || !callbackSchema[httpMethodName]) {
+          continue
+        }
 
-    const httpMethodSchema = callbackSchema[httpMethodName]
-    const httpMethodContainer = {}
+        const httpMethodSchema = callbackSchema[httpMethodName]
+        const httpMethodContainer = {}
 
-    if (httpMethodSchema.requestBody) {
-      httpMethodContainer.requestBody = convertJsonSchemaToOpenapi3(
-        ref.resolve(httpMethodSchema.requestBody)
-      )
-    }
+        if (httpMethodSchema.requestBody) {
+          httpMethodContainer.requestBody = convertJsonSchemaToOpenapi3(
+            ref.resolve(httpMethodSchema.requestBody)
+          )
+        }
 
-    httpMethodContainer.responses = httpMethodSchema.responses
-      ? convertJsonSchemaToOpenapi3(ref.resolve(httpMethodSchema.responses))
-      : { '2XX': { description: 'Default Response' } }
+        // If a response is not provided, set a 2XX default response
+        httpMethodContainer.responses = httpMethodSchema.responses
+          ? convertJsonSchemaToOpenapi3(ref.resolve(httpMethodSchema.responses))
+          : { '2XX': { description: 'Default Response' } }
 
-    callbacksContainer[eventName] = {
-      [callbackUrl]: {
-        [httpMethodName]: httpMethodContainer
+        // Set the schema at the appropriate location in the response object
+        callbacksContainer[eventName][callbackUrl][httpMethodName] = httpMethodContainer
       }
     }
   }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
