### PR TITLE
perf: use optional chaining

### DIFF
--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -64,13 +64,13 @@ module.exports = function (fastify, opts, done) {
   }
 
   function swagger (opts) {
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       if (cache.swaggerString) return cache.swaggerString
     } else {
       if (cache.swaggerObject) return cache.swaggerObject
     }
 
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       const swaggerString = yaml.stringify(swaggerObject, { strict: false })
       cache.swaggerString = swaggerString
       return swaggerString

--- a/lib/spec/openapi/index.js
+++ b/lib/spec/openapi/index.js
@@ -10,7 +10,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
   const defOpts = prepareDefaultOptions(opts)
 
   return function (opts) {
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       if (cache.string) return cache.string
     } else {
       if (cache.object) return cache.object
@@ -74,7 +74,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       ? defOpts.transformObject({ openapiObject })
       : openapiObject
 
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       cache.string = yaml.stringify(transformObjectResult, { strict: false })
       return cache.string
     }

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -265,7 +265,7 @@ function schemaToMediaRecursive (schema) {
 function resolveBodyParams (body, schema, consumes, ref) {
   const resolved = convertJsonSchemaToOpenapi3(ref.resolve(schema))
 
-  if (resolved.content && resolved.content[Object.keys(resolved.content)[0]].schema) {
+  if (resolved.content?.[Object.keys(resolved.content)[0]].schema) {
     for (const contentType in schema.content) {
       body.content[contentType] = schemaToMediaRecursive(resolved.content[contentType].schema)
     }
@@ -279,11 +279,11 @@ function resolveBodyParams (body, schema, consumes, ref) {
       body.content[consume] = media
     })
 
-    if (resolved && resolved.required && resolved.required.length) {
+    if (resolved?.required?.length) {
       body.required = true
     }
 
-    if (resolved && resolved.description) {
+    if (resolved?.description) {
       body.description = resolved.description
     }
   }
@@ -294,7 +294,7 @@ function resolveCommonParams (container, parameters, schema, ref, sharedSchemas,
   let resolved = convertJsonSchemaToOpenapi3(ref.resolve(schema))
 
   // if the resolved definition is in global schema
-  if (resolved.$ref && resolved.$ref.startsWith(schemasPath)) {
+  if (resolved.$ref?.startsWith(schemasPath)) {
     const parts = resolved.$ref.split(schemasPath)
     const pathParts = parts[1].split('/')
     resolved = pathParts.reduce((resolved, pathPart) => resolved[pathPart], ref.definitions().definitions)
@@ -361,7 +361,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
 
     // add schema when type is not 'null'
     if (rawJsonSchema.type !== 'null') {
-      if (resolved.content && resolved.content[Object.keys(resolved.content)[0]].schema) {
+      if (resolved.content?.[Object.keys(resolved.content)[0]].schema) {
         response.content = resolved.content
       } else {
         const content = {}
@@ -446,8 +446,8 @@ function prepareOpenapiMethod (schema, ref, openapiObject, url) {
 
   // Parse out the security prop keys to ignore
   const securityIgnores = [
-    ...(openapiObject && openapiObject.security ? openapiObject.security : []),
-    ...(schema && schema.security ? schema.security : [])
+    ...(openapiObject?.security || []),
+    ...(schema?.security || [])
   ]
     .reduce((acc, securitySchemeGroup) => {
       Object.keys(securitySchemeGroup).forEach((securitySchemeLabel) => {

--- a/lib/spec/swagger/index.js
+++ b/lib/spec/swagger/index.js
@@ -10,7 +10,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
   const defOpts = prepareDefaultOptions(opts)
 
   return function (opts) {
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       if (cache.string) return cache.string
     } else {
       if (cache.object) return cache.object
@@ -66,7 +66,7 @@ module.exports = function (opts, cache, routes, Ref, done) {
       ? defOpts.transformObject({ swaggerObject })
       : swaggerObject
 
-    if (opts && opts.yaml) {
+    if (opts?.yaml) {
       cache.string = yaml.stringify(transformObjectResult, { strict: false })
       return cache.string
     }

--- a/lib/spec/swagger/utils.js
+++ b/lib/spec/swagger/utils.js
@@ -195,7 +195,7 @@ function resolveBodyParams (parameters, schema, ref) {
   parameters.push({
     name: 'body',
     in: 'body',
-    description: resolved && resolved.description ? resolved.description : undefined,
+    description: resolved?.description,
     schema: resolved
   })
 }
@@ -274,8 +274,8 @@ function prepareSwaggerMethod (schema, ref, swaggerObject, url) {
 
   // Parse out the security prop keys to ignore
   const securityIgnores = [
-    ...(swaggerObject && swaggerObject.security ? swaggerObject.security : []),
-    ...(schema && schema.security ? schema.security : [])
+    ...(swaggerObject?.security || []),
+    ...(schema?.security || [])
   ]
     .reduce((acc, securitySchemeGroup) => {
       Object.keys(securitySchemeGroup).forEach((securitySchemeLabel) => {

--- a/lib/util/should-route-hide.js
+++ b/lib/util/should-route-hide.js
@@ -3,11 +3,11 @@
 function shouldRouteHide (schema, opts) {
   const { hiddenTag, hideUntagged } = opts
 
-  if (schema && schema.hide) {
+  if (schema?.hide) {
     return true
   }
 
-  const tags = (schema && schema.tags) || []
+  const tags = schema?.tags || []
 
   if (tags.length === 0 && hideUntagged) {
     return true


### PR DESCRIPTION
Teeny tiny bit faster for a single hop: https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v22.md#optional-chain--vs--operator

Also allows some ternary operators to be changed to or operators.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
