### PR TITLE
perf(lib): replace accumulator spread with object.assign

### DIFF
--- a/lib/util/resolve-local-ref.js
+++ b/lib/util/resolve-local-ref.js
@@ -24,10 +24,7 @@ function resolveLocalRef (jsonSchema, externalSchemas) {
   // for oneOf, anyOf, allOf support in querystring/params/headers
   if (jsonSchema.oneOf || jsonSchema.anyOf || jsonSchema.allOf) {
     const schemas = jsonSchema.oneOf || jsonSchema.anyOf || jsonSchema.allOf
-    return schemas.reduce(function (acc, schema) {
-      const json = resolveLocalRef(schema, externalSchemas)
-      return { ...acc, ...json }
-    }, {})
+    return schemas.reduce((acc, schema) => Object.assign(acc, resolveLocalRef(schema, externalSchemas)), {})
   }
 
   // $ref is in the format: #/definitions/<resolved definition>/<optional fragment>


### PR DESCRIPTION
Ended up stumbling across [this blog post over the holidays](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern), which covers why using spread (`{...obj}`) syntax in accumulators like `reduce` is a bad idea.

TL;DR: it causes a time complexity of `O(n^2)` instead of `O(n)` because it's creating an increasingly growing new object on every iteration. With object.assign, we're mutating the accumulator rather than creating a new object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
