### PR TITLE
fix(types): fix route config options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,9 @@ declare module 'fastify' {
 
   interface FastifyContextConfig {
     swaggerTransform?: fastifySwagger.SwaggerTransform | false;
+    swagger?: {
+      exposeHeadRoute?: boolean
+    }
   }
 }
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -257,3 +257,15 @@ app.register(fastifySwagger, {
 app.register(fastifySwagger, {
   exposeHeadRoutes: false
 })
+
+app.get(
+  '/endpoint-expose-head-route',
+  {
+    config: {
+      swagger: {
+        exposeHeadRoute: true
+      }
+    },
+  },
+  () => {}
+)


### PR DESCRIPTION
Add missing type in the route option. This option is available in the documentation at:
https://github.com/fastify/fastify-swagger?tab=readme-ov-file#route-options

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
