### PR TITLE
fix: prevent mutation of response headers schema

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -344,7 +344,7 @@ function resolveResponse (fastifyResponseJson, produces, ref) {
       response.headers = {}
       Object.keys(rawJsonSchema.headers).forEach(function (key) {
         const header = {
-          schema: rawJsonSchema.headers[key]
+          schema: { ...rawJsonSchema.headers[key] }
         }
 
         if (rawJsonSchema.headers[key].description) {


### PR DESCRIPTION
fixes #868 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
