### PR TITLE
fix: remove defs when ref already defined in schema

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -529,6 +529,11 @@ function convertJsonSchemaToOpenapi3 (jsonSchema) {
       continue
     }
 
+    if (key === '$defs' && Object.keys(openapiSchema).some(schemaKey => schemaKey === '$ref')) {
+      delete openapiSchema[key]
+      continue
+    }
+
     if (key === 'const') {
       // OAS 3.1 supports `const` but it is not supported by `swagger-ui`
       // https://swagger.io/docs/specification/data-models/keywords/

--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -515,6 +515,13 @@ function convertJsonSchemaToOpenapi3 (jsonSchema) {
 
   const openapiSchema = { ...jsonSchema }
 
+  if (Object.hasOwn(openapiSchema, '$ref') && Object.keys(openapiSchema).length !== 1) {
+    for (const key of Object.keys(openapiSchema).filter(k => k !== '$ref')) {
+      delete openapiSchema[key]
+      continue
+    }
+  }
+
   for (const key of Object.keys(openapiSchema)) {
     const value = openapiSchema[key]
 
@@ -526,11 +533,6 @@ function convertJsonSchemaToOpenapi3 (jsonSchema) {
 
     if (key === '$ref') {
       openapiSchema.$ref = value.replace('definitions', 'components/schemas')
-      continue
-    }
-
-    if (key === '$defs' && Object.keys(openapiSchema).some(schemaKey => schemaKey === '$ref')) {
-      delete openapiSchema[key]
       continue
     }
 


### PR DESCRIPTION
When using [TypeBox Modules](https://github.com/sinclairzx81/typebox?tab=readme-ov-file#types-modules) to define Fastify schemas the current implementation duplicates definitions even when using `fastify.addSchema(schema)`. This causes the openapi schema file to be larger and contain duplicate definitions.

If I am correct the OpenApi specification defines that if `$ref` key is defined for object there shouldn't exist other keys on the object (meaning `$defs` shouldn't be there). That is why I've added extra check to `convertJsonSchemaToOpenapi3`to remove `$defs`-key if `$refs`-key exits.

I'm open to suggestions if there's a more appropriate way to resolve this.

Usage example with TypeBox modules:

schema.ts
```typescript
export const HumanModule = Type.Module({
  AddressSchema: Type.Object({
    street: Type.String(),
    streetNumber: Type.Number(),
  }),
  PersonSchema: Type.Object({
    name: Type.String(),
    homeAddress: Type.Ref('AddressSchema'),
    workAddress: Type.Ref('AddressSchema'),
  }),
  PostRequestSchema: Type.Object({
    person: Type.Ref('PersonSchema'),
  }),
});

export const CommonSchema = {
  $id: 'common',
  humanModule: HumanModule,
};

export const PersonSchema = {
  get: {
    response: {
      200: HumanModule.Import('PersonSchema'),
    },
  },
};
```

index.ts
```typescript
const fastify = Fastify();

...

app.addSchema(CommonSchema);
app.get(
  '/person',
  {
    schema: {
      response: {
        200: HumanModule.Import('PersonSchema'),
      },
    },
  },
  async (_request, reply) => {
    return reply.status(200);
  }
);

...

await app.ready();
app.swagger();
```

After the change and using the above style TypeBox module schema definition results in following openapi json:

```json
{
....
  "components": {
    "schemas": {
      "def-0": {
        "humanModule": {
          "$defs": {
            "AddressSchema": {
              "type": "object",
              "properties": {
                "street": { "type": "string" },
                "streetNumber": { "type": "number" }
              },
              "required": ["street", "streetNumber"],
              "title": "AddressSchema"
            },
            "PersonSchema": {
              "type": "object",
              "properties": {
                "name": { "type": "string" },
                "homeAddress": { "$ref": "#/components/schemas/def-1" },
                "workAddress": { "$ref": "#/components/schemas/def-1" }
              },
              "required": ["name", "homeAddress", "workAddress"],
              "title": "PersonSchema"
            },
            "PostRequestSchema": {
              "type": "object",
              "properties": {
                "person": { "$ref": "#/components/schemas/def-2" }
              },
              "required": ["person"],
              "title": "PostRequestSchema"
            }
          }
        },
        "title": "common"
      },
      "def-1": {
        "type": "object",
        "properties": {
          "street": { "type": "string" },
          "streetNumber": { "type": "number" }
        },
        "required": ["street", "streetNumber"],
        "title": "AddressSchema"
      },
      "def-2": {
        "type": "object",
        "properties": {
          "name": { "type": "string" },
          "homeAddress": { "$ref": "#/components/schemas/def-1" },
          "workAddress": { "$ref": "#/components/schemas/def-1" }
        },
        "required": ["name", "homeAddress", "workAddress"],
        "title": "PersonSchema"
      },
      "def-3": {
        "type": "object",
        "properties": { "person": { "$ref": "#/components/schemas/def-2" } },
        "required": ["person"],
        "title": "PostRequestSchema"
      }
    }
  },
  "paths": {
    "/person": {
      "get": {
        "responses": {
          "200": {
            "description": "Default Response",
            "content": {
              "application/json": {
                "schema": { "$ref": "#/components/schemas/def-2" }
              }
            }
          }
        }
      }
    }
  }
  ....
}
```

This PR should fix issue related to https://github.com/fastify/fastify-swagger/issues/854

Related issue on TypeBox repository: https://github.com/sinclairzx81/typebox/issues/1283

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
