### PR TITLE
docs: add note on @fastify/swagger registration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ await fastify.ready()
 fastify.swagger()
 ```
 
+**Note**: `@fastify/swagger` must be registered before any routes to ensure proper route discovery. Routes registered before this plugin will not appear in the generated documentation.
+
 <a name="usage.fastify.autoload"></a>
 ### With `@fastify/autoload`
 


### PR DESCRIPTION
Resolves #890 

## Summary

Adds a clear note about the plugin registration order requirement in the main Usage section to help developers avoid a common gotcha where routes don't appear in generated documentation.

## Changes

- Added note after main usage example explaining `@fastify/swagger` must be registered before routes
- Fixed duplicate variable declaration in autoload example

## Context

The registration order requirement is currently only mentioned in the `@fastify/autoload` section, causing confusion for developers who register routes manually. This leads to empty `/docs/json` endpoints because `@fastify/swagger` uses the `onRoute` hook to discover routes.


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)