### PR TITLE
Remove redundant check

### DIFF
--- a/lib/util/should-route-hide.js
+++ b/lib/util/should-route-hide.js
@@ -14,7 +14,7 @@ function shouldRouteHide (schema, opts) {
   }
 
   if (tags.includes(hiddenTag)) {
-    return schema.tags.includes(hiddenTag)
+    return true
   }
 
   return false

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { test, describe } = require('node:test')
 const { formatParamUrl } = require('../lib/util/format-param-url')
 const { hasParams, matchParams } = require('../lib/util/match-params')
 const { generateParamsSchema, paramName } = require('../lib/util/generate-params-schema')
@@ -21,142 +21,143 @@ const cases = [
   ['/api/v1/postalcode-jp/(^[0-9]{7}$)', '/api/v1/postalcode-jp/{regexp1}']
 ]
 
-test('formatParamUrl', async (t) => {
-  t.plan(cases.length)
-
+describe('formatParamUrl', () => {
   for (const kase of cases) {
-    t.assert.strictEqual(formatParamUrl(kase[0]), kase[1])
+    test(`formatParamUrl ${kase}`, (t) => {
+      t.assert.strictEqual(formatParamUrl(kase[0]), kase[1])
+    })
   }
 })
 
-test('hasParams function', async (t) => {
-  await t.test('should return false for empty url', (t) => {
+describe('hasParams function', () => {
+  test('should return false for empty url', (t) => {
     const url = ''
     const result = hasParams(url)
     t.assert.strictEqual(result, false)
   })
 
-  await t.test('should return true for url with parameters', (t) => {
+  test('should return true for url with parameters', (t) => {
     const url = '/example/{userId}'
     const result = hasParams(url)
     t.assert.strictEqual(result, true)
   })
 
-  await t.test('should return true for url with multiple parameters', (t) => {
+  test('should return true for url with multiple parameters', (t) => {
     const url = '/example/{userId}/{secretToken}'
     const result = hasParams(url)
     t.assert.strictEqual(result, true)
   })
 
-  await t.test('should return false for url without parameters', (t) => {
+  test('should return false for url without parameters', (t) => {
     const url = '/example/path'
     const result = hasParams(url)
     t.assert.strictEqual(result, false)
   })
 })
 
-test('matchParams function', async (t) => {
-  await t.test('should return an empty array for empty url', (t) => {
+describe('matchParams function', (t) => {
+  test('should return an empty array for empty url', (t) => {
     const url = ''
     const result = matchParams(url)
     t.assert.deepStrictEqual(result, [])
   })
 
-  await t.test('should return an array of matched parameters', (t) => {
+  test('should return an array of matched parameters', (t) => {
     const url = '/example/{userId}/{secretToken}'
     const result = matchParams(url)
     t.assert.deepStrictEqual(result, ['{userId}', '{secretToken}'])
   })
 
-  await t.test('should return an empty array for url without parameters', (t) => {
+  test('should return an empty array for url without parameters', (t) => {
     const url = '/example/path'
     const result = matchParams(url)
     t.assert.deepStrictEqual(result, [])
   })
 })
 
-const urlsToShemas = [
-  [
-    '/example/{userId}', {
-      params: {
-        type: 'object',
-        properties: {
-          userId: {
-            type: 'string'
+describe('generateParamsSchema function', (t) => {
+  const urlsToShemas = [
+    [
+      '/example/{userId}', {
+        params: {
+          type: 'object',
+          properties: {
+            userId: {
+              type: 'string'
+            }
           }
         }
       }
-    }
-  ],
-  [
-    '/example/{userId}/{secretToken}', {
-      params: {
-        type: 'object',
-        properties: {
-          userId: {
-            type: 'string'
-          },
-          secretToken: {
-            type: 'string'
+    ],
+    [
+      '/example/{userId}/{secretToken}', {
+        params: {
+          type: 'object',
+          properties: {
+            userId: {
+              type: 'string'
+            },
+            secretToken: {
+              type: 'string'
+            }
           }
         }
       }
-    }
-  ],
-  [
-    '/example/near/{lat}-{lng}', {
-      params: {
-        type: 'object',
-        properties: {
-          lat: {
-            type: 'string'
-          },
-          lng: {
-            type: 'string'
+    ],
+    [
+      '/example/near/{lat}-{lng}', {
+        params: {
+          type: 'object',
+          properties: {
+            lat: {
+              type: 'string'
+            },
+            lng: {
+              type: 'string'
+            }
           }
         }
       }
-    }
+    ]
   ]
-]
 
-test('generateParamsSchema function', (t) => {
-  t.plan(urlsToShemas.length)
-  for (const [url, expectedSchema] of urlsToShemas) {
-    const result = generateParamsSchema(url)
+  test('generateParamsSchema', (t) => {
+    for (const [url, expectedSchema] of urlsToShemas) {
+      const result = generateParamsSchema(url)
 
-    t.assert.deepStrictEqual(result, expectedSchema)
-  }
+      t.assert.deepStrictEqual(result, expectedSchema)
+    }
+  })
 })
 
-test('paramName function', async (t) => {
-  await t.test('should return the captured value from the param', (t) => {
+describe('paramName function', () => {
+  test('should return the captured value from the param', (t) => {
     const param = '{userId}'
     const result = paramName(param)
     t.assert.strictEqual(result, 'userId')
   })
 
-  await t.test('should return the same value if there are no captures', (t) => {
+  test('should return the same value if there are no captures', (t) => {
     const param = 'userId'
     const result = paramName(param)
     t.assert.strictEqual(result, 'userId')
   })
 })
 
-test('shouldRouteHide', async (t) => {
-  await t.test('shouldRouteHide should return true for hidden route', () => {
+describe('shouldRouteHide', () => {
+  test('shouldRouteHide should return true for hidden route', (t) => {
     t.assert.ok(shouldRouteHide({ hide: true }, {}))
   })
 
-  await t.test('shouldRouteHide should return true for hideUntagged', () => {
+  test('shouldRouteHide should return true for hideUntagged', (t) => {
     t.assert.ok(shouldRouteHide({ tags: [] }, { hideUntagged: true }))
   })
 
-  await t.test('shouldRouteHide should return true for hiddenTag', () => {
+  test('shouldRouteHide should return true for hiddenTag', (t) => {
     t.assert.ok(shouldRouteHide({ tags: ['x-test'] }, { hiddenTag: 'x-test' }))
   })
 
-  await t.test('shouldRouteHide should return false for non hidden route', () => {
+  test('shouldRouteHide should return false for non hidden route', (t) => {
     t.assert.equal(shouldRouteHide({}, {}), false)
   })
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -4,6 +4,7 @@ const { test } = require('node:test')
 const { formatParamUrl } = require('../lib/util/format-param-url')
 const { hasParams, matchParams } = require('../lib/util/match-params')
 const { generateParamsSchema, paramName } = require('../lib/util/generate-params-schema')
+const { shouldRouteHide } = require('../lib/util/should-route-hide')
 
 const cases = [
   ['/example/:userId', '/example/{userId}'],
@@ -139,5 +140,23 @@ test('paramName function', async (t) => {
     const param = 'userId'
     const result = paramName(param)
     t.assert.strictEqual(result, 'userId')
+  })
+})
+
+test('shouldRouteHide', async (t) => {
+  t.test('shouldRouteHide should return true for hidden route', () => {
+    t.assert.ok(shouldRouteHide({ hide: true }, {}))
+  })
+
+  t.test('shouldRouteHide should return true for hideUntagged', () => {
+    t.assert.ok(shouldRouteHide({ tags: [] }, { hideUntagged: true }))
+  })
+
+  t.test('shouldRouteHide should return true for hiddenTag', () => {
+    t.assert.ok(shouldRouteHide({ tags: ['x-test'] }, { hiddenTag: 'x-test' }))
+  })
+
+  t.test('shouldRouteHide should return false for non hidden route', () => {
+    t.assert.equal(shouldRouteHide({}, {}), false)
   })
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -144,19 +144,19 @@ test('paramName function', async (t) => {
 })
 
 test('shouldRouteHide', async (t) => {
-  t.test('shouldRouteHide should return true for hidden route', () => {
+  await t.test('shouldRouteHide should return true for hidden route', () => {
     t.assert.ok(shouldRouteHide({ hide: true }, {}))
   })
 
-  t.test('shouldRouteHide should return true for hideUntagged', () => {
+  await t.test('shouldRouteHide should return true for hideUntagged', () => {
     t.assert.ok(shouldRouteHide({ tags: [] }, { hideUntagged: true }))
   })
 
-  t.test('shouldRouteHide should return true for hiddenTag', () => {
+  await t.test('shouldRouteHide should return true for hiddenTag', () => {
     t.assert.ok(shouldRouteHide({ tags: ['x-test'] }, { hiddenTag: 'x-test' }))
   })
 
-  t.test('shouldRouteHide should return false for non hidden route', () => {
+  await t.test('shouldRouteHide should return false for non hidden route', () => {
     t.assert.equal(shouldRouteHide({}, {}), false)
   })
 })


### PR DESCRIPTION
The `if` clauses already checked if `hiddenTag` is included.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
