### PR TITLE
Fix `convertConstToEnum` type typo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -160,17 +160,17 @@ declare namespace fastifySwagger {
         /** `i` is a local counter to generate a unique key. */
         i: number
       ) => string;
-
-      /**
-       * Whether to convert const definitions to enum definitions.
-       *
-       * const support was added in OpenAPI 3.1, but not all tools support it.
-       * This option only affects OpenAPI documents.
-       *
-       * @default true
-       */
-      convertConstToEnum?: boolean;
     }
+
+    /**
+     * Whether to convert const definitions to enum definitions.
+     *
+     * const support was added in OpenAPI 3.1, but not all tools support it.
+     * This option only affects OpenAPI documents.
+     *
+     * @default true
+     */
+    convertConstToEnum?: boolean;
   }
 
   export interface StaticPathSpec {

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,10 +164,8 @@ declare namespace fastifySwagger {
 
     /**
      * Whether to convert const definitions to enum definitions.
-     *
      * const support was added in OpenAPI 3.1, but not all tools support it.
      * This option only affects OpenAPI documents.
-     *
      * @default true
      */
     convertConstToEnum?: boolean;

--- a/test-types/types.test-d.ts
+++ b/test-types/types.test-d.ts
@@ -30,6 +30,7 @@ app.register(fastifySwagger, {
     document: minimalOpenApiV3Document
   }
 })
+app.register(fastifySwagger, { convertConstToEnum: false })
 
 const fastifySwaggerOptions: SwaggerOptions = {
   mode: 'static',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#877 accidentally put the type under `refResolver` :facepalm: 

Added a type test.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
