### PR TITLE
fix(openapi): always set requestBody.required to true when schema.body exists

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -281,10 +281,6 @@ function resolveBodyParams (opts, body, schema, consumes, ref) {
       body.content[consume] = media
     })
 
-    if (resolved?.required?.length) {
-      body.required = true
-    }
-
     if (resolved?.description) {
       body.description = resolved.description
     }
@@ -475,7 +471,9 @@ function prepareOpenapiMethod (opts, schema, ref, openapiObject, url) {
     if (schema.externalDocs) openapiMethod.externalDocs = schema.externalDocs
     if (schema.querystring) resolveCommonParams(opts, 'query', parameters, schema.querystring, ref, openapiObject.definitions, securityIgnores.query)
     if (schema.body) {
-      openapiMethod.requestBody = { content: {} }
+      // Fastify requires a body (at least {}) when schema.body is defined,
+      // so requestBody.required should always be true
+      openapiMethod.requestBody = { required: true, content: {} }
       resolveBodyParams(opts, openapiMethod.requestBody, schema.body, schema.consumes, ref)
     }
     if (schema.params) resolveCommonParams(opts, 'path', parameters, schema.params, ref, openapiObject.definitions)

--- a/test/spec/openapi/option.test.js
+++ b/test/spec/openapi/option.test.js
@@ -1660,6 +1660,38 @@ test('marks request body as required', async (t) => {
   t.assert.deepStrictEqual(requestBody.required, true)
 })
 
+test('marks request body as required even when all properties are optional', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  await fastify.register(fastifySwagger, openapiOption)
+
+  const body = {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    }
+  }
+
+  const opts = {
+    schema: {
+      body
+    }
+  }
+
+  fastify.put('/', opts, () => {})
+
+  await fastify.ready()
+  const openapiObject = fastify.swagger()
+  const requestBody = openapiObject.paths['/'].put.requestBody
+
+  t.assert.ok(requestBody)
+  t.assert.strictEqual(requestBody.required, true)
+  t.assert.ok(requestBody.content['application/json'].schema)
+})
+
 test('openapi webhooks properties', async (t) => {
   t.plan(1)
   const fastify = Fastify()

--- a/test/spec/openapi/schema.test.js
+++ b/test/spec/openapi/schema.test.js
@@ -726,6 +726,7 @@ test('support "const" keyword', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(JSON.parse(JSON.stringify(definedPath.requestBody)), {
+    required: true,
     content: {
       'application/json': {
         schema: {
@@ -793,6 +794,7 @@ test('convert "const" to "enum"', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(JSON.parse(JSON.stringify(definedPath.requestBody)), {
+    required: true,
     content: {
       'application/json': {
         schema: {
@@ -855,6 +857,7 @@ test('support object properties named "const"', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(JSON.parse(JSON.stringify(definedPath.requestBody)), {
+    required: true,
     content: {
       'application/json': {
         schema: {
@@ -914,6 +917,7 @@ test('support object properties with special names', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(JSON.parse(JSON.stringify(definedPath.requestBody)), {
+    required: true,
     content: {
       'application/json': {
         schema: {
@@ -968,6 +972,7 @@ test('support "description" keyword', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(JSON.parse(JSON.stringify(definedPath.requestBody)), {
+    required: true,
     description: 'Body description',
     content: {
       'application/json': {
@@ -1239,6 +1244,7 @@ test('support multiple content types as request', async t => {
 
   const definedPath = api.paths['/'].post
   t.assert.deepStrictEqual(definedPath.requestBody, {
+    required: true,
     content: {
       'application/json': {
         schema: {


### PR DESCRIPTION
Fastify requires a body when schema.body is defined, even if all properties are optional. This ensures the OpenAPI spec correctly reflects Fastify's runtime behavior. This solves the issue #894

## Problem

When a route has `schema.body` defined, Fastify requires that the request includes a body (at least `{}`), even if all properties inside that body are optional. However, the OpenAPI schema generated by `@fastify/swagger` was only setting `requestBody.required` to `true` when there were required properties inside the object. If the object had only optional properties, then `requestBody.required` was omitted, incorrectly marking the request body as optional.

This mismatch between the OpenAPI spec and Fastify's actual runtime behavior can mislead client code generators and API consumers.

## Solution

This fix ensures that `requestBody.required` is always set to `true` when `schema.body` is defined, regardless of whether any properties inside the body are required. The fix sets `required: true` when creating the `requestBody` object in `prepareOpenapiMethod`, making it explicit that the body is required whenever a body schema is defined.

## Example

**Before (incorrect):**

```json
{
  "requestBody": {
    "content": {
      "application/json": {
        "schema": {
          "type": "object",
          "properties": {
            "hello": { "type": "string" }
          }
        }
      }
    }
  }
}
```

**After (correct):**

```json
{
  "requestBody": {
    "required": true,
    "content": {
      "application/json": {
        "schema": {
          "type": "object",
          "properties": {
            "hello": { "type": "string" }
          }
        }
      }
    }
  }
}
```

## Changes

- Set `required: true` when creating `requestBody` object in `prepareOpenapiMethod`
- Added test case for body with only optional properties
- Updated existing tests to expect `required: true` when `schema.body` is defined

Fixes the issue where the OpenAPI spec incorrectly showed `requestBody` as optional when Fastify actually requires it at runtime.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
