### PR TITLE
chore: ignore local AI assistant files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,9 @@ yarn.lock
 
 # static files
 static
+
+# AI assistant local config
+.pi
+.claude
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary
- add local AI assistant directories to .gitignore (`.pi`, `.claude`)
- ignore agent guidance files (`AGENTS.md`, `CLAUDE.md`)

## Why
These files are environment-specific and should not be committed to the repository.
