### PR TITLE
fix(openapi): convert contentEncoding to format for file uploads

### DIFF
--- a/lib/spec/openapi/utils.js
+++ b/lib/spec/openapi/utils.js
@@ -549,6 +549,16 @@ function convertJsonSchemaToOpenapi3 (opts, jsonSchema) {
       continue
     }
 
+    if (key === 'contentEncoding') {
+      if (value === 'binary') {
+        openapiSchema.format = 'binary'
+      } else if (value === 'base64') {
+        openapiSchema.format = 'byte'
+      }
+      delete openapiSchema.contentEncoding
+      continue
+    }
+
     if (key === 'patternProperties') {
       // TODO: check if additionalProperties property already exists
       // TODO: this breaks references to the additionalProperties properties

--- a/test/spec/openapi/schema.test.js
+++ b/test/spec/openapi/schema.test.js
@@ -10,6 +10,84 @@ const {
   schemaAllOf
 } = require('../../../examples/options')
 
+test('support file in json schema', async t => {
+  const opts = {
+    schema: {
+      consumes: ['multipart/form-data'],
+      body: {
+        type: 'object',
+        properties: {
+          file: {
+            description: 'a file',
+            type: 'string',
+            contentEncoding: 'binary'
+          }
+        },
+        required: ['file']
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, openapiOption)
+  fastify.post('/', opts, () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+
+  const definedPath = api.paths['/'].post
+  t.assert.ok(definedPath)
+  t.assert.deepStrictEqual(
+    definedPath.requestBody.content['multipart/form-data'].schema.properties.file,
+    {
+      description: 'a file',
+      type: 'string',
+      format: 'binary'
+    }
+  )
+})
+
+test('support base64 contentEncoding in json schema', async t => {
+  const opts = {
+    schema: {
+      consumes: ['multipart/form-data'],
+      body: {
+        type: 'object',
+        properties: {
+          file: {
+            description: 'a base64 file',
+            type: 'string',
+            contentEncoding: 'base64'
+          }
+        },
+        required: ['file']
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, openapiOption)
+  fastify.post('/', opts, () => {})
+
+  await fastify.ready()
+
+  const openapiObject = fastify.swagger()
+  const api = await Swagger.validate(openapiObject)
+
+  const definedPath = api.paths['/'].post
+  t.assert.ok(definedPath)
+  t.assert.deepStrictEqual(
+    definedPath.requestBody.content['multipart/form-data'].schema.properties.file,
+    {
+      description: 'a base64 file',
+      type: 'string',
+      format: 'byte'
+    }
+  )
+})
+
 test('support - oneOf, anyOf, allOf', async (t) => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
## Summary
- Converts JSON Schema `contentEncoding: 'binary'` to OpenAPI 3.0 `format: 'binary'` so Swagger UI shows a file picker for multipart file uploads
- Also handles `contentEncoding: 'base64'` → `format: 'byte'`

Closes #800

## Test plan
- [x] Added test for `contentEncoding: 'binary'` → `format: 'binary'` with `multipart/form-data`
- [x] Added test for `contentEncoding: 'base64'` → `format: 'byte'`
- [x] All existing tests pass with 100% coverage
- [x] Generated spec validated by `@apidevtools/swagger-parser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)