### PR TITLE
fix(static): use path.resolve for baseDir to ensure cross-platform compatibility

### DIFF
--- a/lib/mode/static.js
+++ b/lib/mode/static.js
@@ -18,7 +18,7 @@ module.exports = function (fastify, opts, done) {
     if (!fs.existsSync(path.resolve(opts.specification.path))) return done(new Error(`${opts.specification.path} does not exist`))
 
     const extName = path.extname(opts.specification.path).toLowerCase()
-    if (['.yaml', '.json'].indexOf(extName) === -1) return done(new Error("specification.path extension name is not supported, should be one from ['.yaml', '.json']"))
+    if (['.yaml', '.yml', '.json'].indexOf(extName) === -1) return done(new Error("specification.path extension name is not supported, should be one from ['.yaml', '.yml', '.json']"))
 
     if (opts.specification.postProcessor && typeof opts.specification.postProcessor !== 'function') return done(new Error('specification.postProcessor should be a function'))
 
@@ -27,9 +27,7 @@ module.exports = function (fastify, opts, done) {
     if (!opts.specification.baseDir) {
       opts.specification.baseDir = path.resolve(path.dirname(opts.specification.path))
     } else {
-      while (opts.specification.baseDir.endsWith('/')) {
-        opts.specification.baseDir = opts.specification.baseDir.slice(0, -1)
-      }
+      opts.specification.baseDir = path.resolve(opts.specification.baseDir)
     }
 
     // read
@@ -39,6 +37,7 @@ module.exports = function (fastify, opts, done) {
     )
     switch (extName) {
       case '.yaml':
+      case '.yml':
         swaggerObject = yaml.parse(source)
         break
       case '.json':


### PR DESCRIPTION
Replaced the manual trailing slash removal with path.resolve() in lib/mode/static.js to properly handle file paths across different operating systems. This avoids potential issues where manual path manipulation fails on non-Unix platforms and ensures a consistent absolute path for baseDir.